### PR TITLE
[feature: add support for configuration of signing order [refs:issue 89]

### DIFF
--- a/src/entity-idp.ts
+++ b/src/entity-idp.ts
@@ -77,14 +77,15 @@ export class IdentityProvider extends Entity {
   * @param  {string}   binding                   protocol binding
   * @param  {object}   user                      current logged user (e.g. req.user)
   * @param  {function} customTagReplacement      used when developers have their own login response template
+  * @param  {boolean}  encryptThenSign           whether or not to encrypt then sign first (if signing)
   */
-  public async createLoginResponse(sp, requestInfo, binding, user, customTagReplacement?) {
+  public async createLoginResponse(sp, requestInfo, binding, user, customTagReplacement?, encryptThenSign?) {
     const protocol = namespace.binding[binding] || namespace.binding.redirect;
     if (protocol === namespace.binding.post) {
       const context = await postBinding.base64LoginResponse(requestInfo, {
         idp: this,
         sp,
-      }, user, customTagReplacement);
+      }, user, customTagReplacement, encryptThenSign);
       // xmlenc is using async process
       return {
         ...context,

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -4,7 +4,7 @@
 * @desc  An abstraction for identity provider and service provider.
 */
 import { base64Decode, isNonEmptyArray, inflateString } from './utility';
-import { namespace, wording, algorithms } from './urn';
+import { namespace, wording, algorithms, messageConfigurations } from './urn';
 import * as uuid from 'uuid';
 import libsaml from './libsaml';
 import Metadata from './metadata';
@@ -19,10 +19,12 @@ const dataEncryptionAlgorithm = algorithms.encryption.data;
 const keyEncryptionAlgorithm = algorithms.encryption.key;
 const bindDict = wording.binding;
 const signatureAlgorithms = algorithms.signature;
+const messageSigningOrders = messageConfigurations.signingOrder;
 const nsBinding = namespace.binding;
 
 const defaultEntitySetting = {
   wantLogoutResponseSigned: false,
+  messageSigningOrder: messageSigningOrders.SIGN_THEN_ENCRYPT,
   wantLogoutRequestSigned: false,
   allowCreate: false,
   isAssertionEncrypted: false,
@@ -233,6 +235,17 @@ export default class Entity {
       const encodedRequest = body[libsaml.getQueryParamByType(parserType)];
       let res = String(base64Decode(encodedRequest));
       const issuer = targetEntityMetadata.getEntityID();
+      //verify signature before decryption if IDP encrypted then signed the message
+      if (checkSignature && from.entitySetting.messageSigningOrder === messageSigningOrders.ENCRYPT_THEN_SIGN) {
+
+        // verify the signatures (for both assertion/message)
+        if (!libsaml.verifySignature(res, {
+            cert: opts.from.entityMeta,
+            signatureAlgorithm: opts.from.entitySetting.requestSignatureAlgorithm,
+          })) {
+          throw new Error('incorrect signature');
+        }
+      }
       if (parserType === 'SAMLResponse' && from.entitySetting.isAssertionEncrypted) {
         res = await libsaml.decryptAssertion(here, res);
       }
@@ -240,7 +253,7 @@ export default class Entity {
         samlContent: res,
         extract: libsaml.extractor(res, fields),
       };
-      if (checkSignature) {
+      if (checkSignature && from.entitySetting.messageSigningOrder === messageSigningOrders.SIGN_THEN_ENCRYPT) {
         // verify the signatures (for both assertion/message)
         if (!libsaml.verifySignature(res, {
           cert: opts.from.entityMeta,

--- a/src/urn.ts
+++ b/src/urn.ts
@@ -92,6 +92,13 @@ const tags = {
   },
 };
 
+const messageConfigurations = {
+  signingOrder: {
+    SIGN_THEN_ENCRYPT: 'sign-then-encrypt',
+    ENCRYPT_THEN_SIGN: 'encrypt-then-sign',
+  },
+};
+
 const algorithms = {
   signature: {
     RSA_SHA1: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
@@ -149,4 +156,4 @@ const elementsOrder = {
   shibboleth: ['KeyDescriptor', 'SingleLogoutService', 'NameIDFormat', 'AssertionConsumerService', 'AttributeConsumingService'],
 };
 
-export { namespace, tags, algorithms, wording, elementsOrder };
+export { namespace, tags, algorithms, wording, elementsOrder, messageConfigurations };


### PR DESCRIPTION
Added configurations for the signing order ('sign-then-encrypt' and 'encrypt-then-sign'). I, also,  added a test case. They were all passing, before 2.0.1 bump.  I, also, deployed this to my container and verified it worked with OKTA with a signed and encrypted assertion Login Response.

Used the below configuration on my SP-side to initialize IDP with new config option:
idp = IdentityProvider({
				metadata: fs.readFileSync(.....idpFile)),
				isAssertionEncrypted: true,
				messageSigningOrder: 'encrypt-then-sign'
			});