### PR TITLE
Chore: Add typings to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "slo",
     "metadata"
   ],
+  "typings": "./index.ts",
   "scripts": {
     "build": "npm run lint && tsc",
     "build:nolint": "tsc",


### PR DESCRIPTION
This will enable the ability to use the internal project types instead of needing separately published types on DefinitelyTyped.

See #97 