### PR TITLE
Parses SessionIndex in the login response

### DIFF
--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -106,6 +106,9 @@ export class ServiceProvider extends Entity {
           key: 'Name',
         },
         valueTag: 'AttributeValue',
+      }, {
+        localName: 'AuthnStatement',
+        attributes: ['SessionIndex'],
       }],
       from: idp,
       checkSignature: true, // saml response must have signature


### PR DESCRIPTION
@tngan Not sure if this is the way to go, but It seems that `samlify` needs the `SessionIndex` to start a logout request. However, is not parse during the loginResponse. So, this PRs adds it.