### PR TITLE
Fix yarn install guide for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project is now developed using TypeScript 2.0, also support Yarn which is a
 
 ```bash
 $ npm install typescript -g
-$ yarn
+$ yarn global add typescript
 ```
 
 ### Integrations

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ $ yarn add samlify
 This project is now developed using TypeScript 2.0, also support Yarn which is a new package manager.
 
 ```bash
-$ npm install typescript -g
 $ yarn global add typescript
+$ yarn
 ```
 
 ### Integrations


### PR DESCRIPTION
Should be `yarn global add typescript`?