### PR TITLE
reverting chdir after libxml-xsd parsing

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -14,6 +14,7 @@ import redirectBinding from './binding-redirect';
 import postBinding from './binding-post';
 import { isString, isUndefined, isArray, get } from 'lodash';
 import * as url from 'url';
+import * as path from 'path';
 import { MetadataIdpConstructor, MetadataSpConstructor, EntitySetting } from './types';
 
 const dataEncryptionAlgorithm = algorithms.encryption.data;
@@ -201,7 +202,12 @@ export default class Entity {
       }
       const xmlString = inflateString(decodeURIComponent(samlContent));
       if (parserType === 'SAMLResponse') {
-        await libsaml.isValidXml(xmlString);
+        const currentDirectory = path.resolve('');
+        try {
+            await libsaml.isValidXml(xmlString);
+        } finally {
+          process.chdir(currentDirectory);  //revert back to oem working dir
+        }
       }
       if (checkSignature) {
         const { SigAlg: sigAlg, Signature: signature } = reqQuery;
@@ -246,7 +252,12 @@ export default class Entity {
         }
       }
       if (parserType === 'SAMLResponse' && from.entitySetting.isAssertionEncrypted) {
-        res = await libsaml.decryptAssertion(here, res);
+        const currentDirectory = path.resolve('');
+        try {
+            res = await libsaml.decryptAssertion(here, res);
+        } finally {
+          process.chdir(currentDirectory);  //revert back to oem working dir
+        }
       }
       if (parserType === 'SAMLResponse') {
         await libsaml.isValidXml(res);

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -707,6 +707,7 @@ const libSaml = () => {
         const currentDirectory = path.resolve('');
         process.chdir(path.resolve(__dirname, '../schemas'));
         xsd.parseFile(path.resolve('saml-schema-protocol-2.0.xsd'), (err, schema) => {
+          process.chdir(currentDirectory);  //revert back to oem working dir
           if (err) {
             return reject(err.message);
           }

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -707,7 +707,6 @@ const libSaml = () => {
         const currentDirectory = path.resolve('');
         process.chdir(path.resolve(__dirname, '../schemas'));
         xsd.parseFile(path.resolve('saml-schema-protocol-2.0.xsd'), (err, schema) => {
-          process.chdir(currentDirectory);  //revert back to oem working dir
           if (err) {
             return reject(err.message);
           }


### PR DESCRIPTION
Need to revert working directory to original, after finding/parsing xsd schema in libSaml.

This is (was) causing major issues in my codebase because of wrong working directory, after calling 'parseLoginResonse'...could not find other files (the breadcrumb).

Please merge/bump at your soonest convenience, so I can upgrade from 2.2.0 and fix security "hole".