### PR TITLE
Minor grammar fixes in documentation

### DIFF
--- a/docs/advance.md
+++ b/docs/advance.md
@@ -8,4 +8,4 @@ Thanks for your patience. Reading documentation is a tough job, so that we keep 
 + Metadata distribution
 + Configuration of Identity/Service Provider w/o metadata
 
-If you have ideas and want more examples, please don't be hesitate to create an issue in our Github repository. 
+If you have ideas and want more examples, please don't hesitate to create an issue in our Github repository. 

--- a/docs/encrypted-saml-response.md
+++ b/docs/encrypted-saml-response.md
@@ -31,7 +31,7 @@ Now all you need to do is to use `sp.parseLoginResponse` again to parse and veri
 router.post('/acs', (req, res) => {
   sp.parseLoginResponse(idp, 'post', req)
   .then(parseResult => {
-    // Use the parseResult can do customized action
+    // Use the parseResult to do customized action
   })
   .catch(console.error);
 });


### PR DESCRIPTION
Just a few minor grammar errors in the documentation that needed fixing.