### PR TITLE
Fixed verifyTime not working with local time

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -142,18 +142,21 @@ export default class Entity {
   */
   verifyTime(notBefore?: Date, notOnOrAfter?: Date): boolean {
     const now = new Date();
-    const notBeforeLocal = new Date(notBefore.toUTCString());
-    const notOnOrAfterLocal = new Date(notOnOrAfter.toUTCString());
     if (isUndefined(notBefore) && isUndefined(notOnOrAfter)) {
       return true; // throw exception todo
     }
     if (!isUndefined(notBefore) && isUndefined(notOnOrAfter)) {
+      const notBeforeLocal = new Date(notBefore.toUTCString());
       return +notBeforeLocal <= +now;
     }
     if (isUndefined(notBefore) && !isUndefined(notOnOrAfter)) {
+      const notOnOrAfterLocal = new Date(notOnOrAfter.toUTCString());
       return now < notOnOrAfterLocal;
+    } else {
+      const notBeforeLocal = new Date(notBefore.toUTCString());
+      const notOnOrAfterLocal = new Date(notOnOrAfter.toUTCString());
+      return +notBeforeLocal <= +now && now < notOnOrAfterLocal;
     }
-    return +notBeforeLocal <= +now && now < notOnOrAfterLocal;
   }
   /**
   * @desc  Validate and parse the request/response with different bindings

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -142,16 +142,18 @@ export default class Entity {
   */
   verifyTime(notBefore?: Date, notOnOrAfter?: Date): boolean {
     const now = new Date();
+    const notBeforeLocal = new Date(notBefore.toUTCString());
+    const notOnOrAfterLocal = new Date(notOnOrAfter.toUTCString());
     if (isUndefined(notBefore) && isUndefined(notOnOrAfter)) {
       return true; // throw exception todo
     }
     if (!isUndefined(notBefore) && isUndefined(notOnOrAfter)) {
-      return +notBefore <= +now;
+      return +notBeforeLocal <= +now;
     }
     if (isUndefined(notBefore) && !isUndefined(notOnOrAfter)) {
-      return now < notOnOrAfter;
+      return now < notOnOrAfterLocal;
     }
-    return +notBefore <= +now && now < notOnOrAfter;
+    return +notBeforeLocal <= +now && now < notOnOrAfterLocal;
   }
   /**
   * @desc  Validate and parse the request/response with different bindings


### PR DESCRIPTION
The `notBefore` and `notOnOrAfter` are UTC while `now` is the local date. This way the comparison can not work.
The added variables should fix this.

(ref: https://praveenlobo.com/blog/how-to-convert-javascript-local-date-to-utc-and-utc-to-local-date/)