### PR TITLE
Add SessionIndex to sp-initiated logout request

### DIFF
--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -141,7 +141,7 @@ const libSaml = () => {
   * @type {LogoutRequestTemplate}
   */
   const defaultLogoutRequestTemplate = {
-    context: '<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" IssueInstant="{IssueInstant}" Destination="{Destination}"><saml:Issuer>{Issuer}</saml:Issuer><saml:NameID SPNameQualifier="{EntityID}" Format="{NameIDFormat}">{NameID}</saml:NameID></samlp:LogoutRequest>',
+    context: '<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" IssueInstant="{IssueInstant}" Destination="{Destination}"><saml:Issuer>{Issuer}</saml:Issuer><saml:NameID SPNameQualifier="{EntityID}" Format="{NameIDFormat}">{NameID}</saml:NameID><samlp:SessionIndex>{SessionIndex}</samlp:SessionIndex></samlp:LogoutRequest>',
   };
   /**
   * @desc Default login response template

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -214,12 +214,12 @@ test('create post login response', async t => {
 });
 
 test('create logout request with redirect binding', t => {
-  const { id, context } = sp.createLogoutRequest(idp, 'redirect', { email: 'user@esaml2' });
+  const { id, context } = sp.createLogoutRequest(idp, 'redirect', { logoutNameID: 'user@esaml2' });
   _.isString(id) && _.isString(context) ? t.pass() : t.fail();
 });
 
 test('create logout request with post binding', t => {
-  const { relayState, type, entityEndpoint, id, context } = sp.createLogoutRequest(idp, 'post', { email: 'user@esaml2' }) as PostBindingContext;
+  const { relayState, type, entityEndpoint, id, context } = sp.createLogoutRequest(idp, 'post', { logoutNameID: 'user@esaml2' }) as PostBindingContext;
   _.isString(id) && _.isString(context) && _.isString(entityEndpoint) && _.isEqual(type, 'SAMLRequest') ? t.pass() : t.fail();
 });
 


### PR DESCRIPTION
Adding SessionIndex to sp-initiated logout request. Updating `defaultLogoutRequestTemplate` context to include: `<samlp:SessionIndex>{SessionIndex}</samlp:SessionIndex>`

Correcting flow.ts -> sp.createLogoutRequest example. `user` object should be using `logoutNameID` instead of `email`.