### PR TITLE
Validation and relay state customization

### DIFF
--- a/src/binding-redirect.ts
+++ b/src/binding-redirect.ts
@@ -72,10 +72,11 @@ function buildRedirectURL(opts: BuildRedirectConfig) {
 * @param  {function} customTagReplacement      used when developers have their own login response template
 * @return {string} redirect URL
 */
-function loginRequestRedirectURL(entity: { idp: Idp, sp: Sp }, customTagReplacement?: (template: string) => BindingContext): BindingContext {
+function loginRequestRedirectURL(entity: { idp: Idp, sp: Sp, relayState?: string }, customTagReplacement?: (template: string) => BindingContext): BindingContext {
 
   const metadata: any = { idp: entity.idp.entityMeta, sp: entity.sp.entityMeta };
   const spSetting: any = entity.sp.entitySetting;
+  const relayState = entity.relayState === undefined ? spSetting.relayState : entity.relayState;
   let id: string = '';
 
   if (metadata && metadata.idp && metadata.sp) {
@@ -106,7 +107,7 @@ function loginRequestRedirectURL(entity: { idp: Idp, sp: Sp }, customTagReplacem
         isSigned: metadata.sp.isAuthnRequestSigned(),
         entitySetting: spSetting,
         baseUrl: base,
-        relayState: spSetting.relayState,
+        relayState,
       }),
     };
   }

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -12,6 +12,7 @@ import {
   IdentityProviderConstructor as IdentityProvider,
   ServiceProviderMetadata,
   ServiceProviderSettings,
+  ValidationSettings,
 } from './types';
 import { namespace } from './urn';
 import redirectBinding from './binding-redirect';
@@ -50,7 +51,7 @@ export class ServiceProvider extends Entity {
   * @desc  Generates the login request for developers to design their own method
   * @param  {IdentityProvider} idp               object of identity provider
   * @param  {string}   binding                   protocol binding
-  * @param  {function} customTagReplacement     used when developers have their own login response template
+  * @param  {function} customTagReplacement      used when developers have their own login response template
   * @param  {string}   relayState                optionally override default SP relayState
   */
   public createLoginRequest(
@@ -91,10 +92,12 @@ export class ServiceProvider extends Entity {
   * @param  {IdentityProvider}   idp             object of identity provider
   * @param  {string}   binding                   protocol binding
   * @param  {request}   req                      request
+  * @param  {ValidationSettings}   validation    optionally skip some validations
   */
-  public parseLoginResponse(idp, binding, request: ESamlHttpRequest) {
+  public parseLoginResponse(idp, binding, request: ESamlHttpRequest, validation?: ValidationSettings) {
     const self = this;
-    return flow({
+
+    const options = {
       from: idp,
       self: self,
       checkSignature: true, // saml response must have signature
@@ -102,7 +105,13 @@ export class ServiceProvider extends Entity {
       type: 'login',
       binding: binding,
       request: request
-    });
+    };
+
+    if (validation) {
+      Object.assign(options, validation);
+    }
+
+    return flow(options);
   }
 
 }

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -118,7 +118,10 @@ async function postFlow(options): Promise<FlowResult> {
     from,
     self,
     parserType,
-    checkSignature = true
+    checkSignature = true,
+    checkIssuer = true,
+    checkSessionTime = true,
+    checkTime = true
   } = options;
 
   const { body } = request;
@@ -189,6 +192,7 @@ async function postFlow(options): Promise<FlowResult> {
 
   // unmatched issuer
   if (
+    checkIssuer &&
     (parserType === 'LogoutResponse' || parserType === 'SAMLResponse')
     && extractedProperties
     && extractedProperties.issuer !== issuer
@@ -198,6 +202,7 @@ async function postFlow(options): Promise<FlowResult> {
 
   // invalid session time
   if (
+    checkSessionTime &&
     parserType === 'SAMLResponse'
     && !verifyTime(
       undefined,
@@ -210,6 +215,7 @@ async function postFlow(options): Promise<FlowResult> {
   // invalid time
   // 2.4.1.2 https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
   if (
+    checkTime &&
     parserType === 'SAMLResponse'
     && extractedProperties.conditions
     && !verifyTime(

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,3 +118,10 @@ export interface IdentityProviderSettings {
   wantLogoutRequestSignedResponseSigned?: boolean;
   tagPrefix?: { [key: string]: string };
 }
+
+export interface ValidationSettings {
+  checkSignature?: boolean;
+  checkIssuer?: boolean;
+  checkSessionTime?: boolean;
+  checkTime?: boolean;
+}


### PR DESCRIPTION
This library is awesome in its simplicity and straightforwardness, nevertheless, I've encountered 2 things that were missing IMO.

Luckily, they were pretty easy to solve:
1. The relayState parameter had to be set directly on the ServiceProvider entity, which required creating a new provider each time a login request had to be created with a different relay state. (That was already discussed in #163)
2. All validations were mandatory. My specific concern was the issuer validation, since my app is multi-tenant, and I would like to be able to get SAML responses from multiple issuers into the same endpoint, then dispatching them to the right client based on the issuer.