### PR TITLE
add all validators as optional dependencies in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ node_js:
   - "8"
   - "10"
 
+env:
+  - INSTALL_JDK=1
+  - INSTALL_JDK=0
+
 before_install:
-  - sudo add-apt-repository ppa:openjdk-r/ppa -y
-  - sudo apt-get -qq update
-  - sudo apt-get install -y openjdk-9-jdk
-  - export SAML_VALIDATOR=javac
+  - if [[ "$INSTALL_JDK" == "1" ]] ; then make install_jdk ; fi
 
 script:
   - npm test

--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,19 @@ pretest:	;
 
 validator: ;
 ifeq ($(SAML_VALIDATOR), javac)
-	@echo "Installing java xsd schema validator ...";
+	@echo "Using java xsd schema validator ...";
 	# for java runtime support library
 	# need to run with npm install, yarn add --ignore-scripts will ignore the postinstall script
 	# check more information in the package.json of @authenio/xsd-schema-validator
-	npm install @authenio/xsd-schema-validator;
+	# npm install @authenio/xsd-schema-validator;
 
 else ifeq ($(SAML_VALIDATOR), libxml)
-	@echo "Installing libxml-xsd ...";
-	npm install libxml-xsd
+	@echo "Using libxml-xsd ...";
+	# npm install libxml-xsd
 
 else ifeq ($(SAML_VALIDATOR), xmllint)
-	@echo "Installing node-xmllint ...";
-	npm i node-xmllint
+	@echo "Using node-xmllint ...";
+	# npm i node-xmllint
 
 else
 	@echo "No valid SAML_VALIDATOR is chosen";

--- a/Makefile
+++ b/Makefile
@@ -17,26 +17,13 @@ pretest:	;
 					cp -a test/key test/misc build/test;
 
 validator: ;
-ifeq ($(SAML_VALIDATOR), javac)
-	@echo "Using java xsd schema validator ...";
-	# for java runtime support library
-	# need to run with npm install, yarn add --ignore-scripts will ignore the postinstall script
-	# check more information in the package.json of @authenio/xsd-schema-validator
-	# npm install @authenio/xsd-schema-validator;
 
-else ifeq ($(SAML_VALIDATOR), libxml)
-	@echo "Using libxml-xsd ...";
-	# npm install libxml-xsd
-
-else ifeq ($(SAML_VALIDATOR), xmllint)
-	@echo "Using node-xmllint ...";
-	# npm i node-xmllint
-
-else
-	@echo "No valid SAML_VALIDATOR is chosen";
-endif
+install_jdk:
+	sudo add-apt-repository ppa:openjdk-r/ppa -y
+	sudo apt-get -qq update
+	sudo apt-get install -y openjdk-9-jdk
 
 doc: ;@echo "prepare and serve the docs"; \
 	   docsify serve ./docs
 
-.PHONY: rebuild pretest doc validator
+.PHONY: rebuild pretest doc validator install_jdk

--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ Welcome all PRs for maintaining this project, or provide a link to the repositor
 ### Installation
 To install the stable version
 
-Starting from v2.5, schema validation becomes selectable and optional, we restrict to apply it in your production environment, you can only ignore schema validation in development mode. When you install samlify in your current project, please assign the environment variable `SAML_VALIDATOR` to either `javac`, `xmllint` or `libxml`.
-
-```console
-$ SAML_VALIDATOR=javac yarn add samlify
-```
+Starting from v2.5, multiple schema validators have become available. All three of `@authenio/xsd-schema-validator`, `libxml-xsd` and `node-xmllint`are included as 'optional' dependencies, and will be preferentially used in that order. If one has failed to install, the next in the list will be used.
 
 For those using Windows, `windows-build-tools` should be installed globally before installing samlify if you are using `libxml` validator.
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@authenio/xml-encryption": "^0.11.2",
     "camelcase": "^5.2.0",
     "deflate-js": "^0.2.3",
     "node-forge": "^0.7.5",
@@ -43,6 +42,11 @@
     "xml-crypto": "^1.1.4",
     "xmldom": "^0.1.19",
     "xpath": "^0.0.27"
+  },
+  "optionalDependencies": {
+    "@authenio/xml-encryption": "^0.11.2",
+    "libxml-xsd": "^0.5.2",
+    "node-xmllint": "^1.0.0"
   },
   "devDependencies": {
     "@types/camelcase": "^5.2.0",

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -71,6 +71,15 @@ const defaultIdpConfig = {
   metadata: readFileSync('./test/misc/idpmeta.xml'),
 };
 
+const oneloginIdpConfig = {
+  privateKey: readFileSync('./test/key/idp/privkey.pem'),
+  privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+  isAssertionEncrypted: true,
+  encPrivateKey: readFileSync('./test/key/idp/encryptKey.pem'),
+  encPrivateKeyPass: 'g7hGcRmp8PxT5QeP2q9Ehf1bWe9zTALN',
+  metadata: readFileSync('./test/misc/idpmeta_onelogoutservice.xml'),
+};
+
 const defaultSpConfig = {
   privateKey: readFileSync('./test/key/sp/privkey.pem'),
   privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
@@ -216,15 +225,7 @@ test('create logout request with post binding', t => {
 });
 
 test('create logout request when idp only has one binding', t => {
-  const testIdpConfig = {
-    privateKey: readFileSync('./test/key/idp/privkey.pem'),
-    privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
-    isAssertionEncrypted: true,
-    encPrivateKey: readFileSync('./test/key/idp/encryptKey.pem'),
-    encPrivateKeyPass: 'g7hGcRmp8PxT5QeP2q9Ehf1bWe9zTALN',
-    metadata: readFileSync('./test/misc/idpmeta_onelogoutservice.xml'),
-  };
-  const testIdp = identityProvider(testIdpConfig);
+  const testIdp = identityProvider(oneloginIdpConfig);
   const { id, context } = sp.createLogoutRequest(testIdp, 'redirect', { logoutNameID: 'user@esaml2' });
   isString(id) && isString(context) ? t.pass() : t.fail();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -788,6 +788,13 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.0.tgz#9523e001306a32444b907423f1de2164222f6ab1"
   integrity sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==
 
+bindings@^1.2.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bluebird@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
@@ -1582,6 +1589,11 @@ figures@^2.0.0:
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -2515,6 +2527,23 @@ lcov-parse@^0.0.10:
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
   integrity sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=
 
+libxml-xsd@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/libxml-xsd/-/libxml-xsd-0.5.2.tgz#e5e5ee13d301a4d33af3bc4a7886991a5fd15a37"
+  integrity sha1-5eXuE9MBpNM687xKeIaZGl/RWjc=
+  dependencies:
+    bindings "^1.2.1"
+    libxmljs-mt "0.16.1"
+    nan "^2.1.0"
+
+libxmljs-mt@0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/libxmljs-mt/-/libxmljs-mt-0.16.1.tgz#b10f783d64b7b54d8f3f26efc69da2d005d4f57b"
+  integrity sha1-sQ94PWS3tU2PPybvxp2i0AXU9Xs=
+  dependencies:
+    bindings "^1.2.1"
+    nan "^2.0.7"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -2884,6 +2913,11 @@ multimatch@^3.0.0:
     arrify "^1.0.1"
     minimatch "^3.0.4"
 
+nan@^2.0.7, nan@^2.1.0:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
+  integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
+
 nan@^2.9.2:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.0.tgz#7bdfc27dd3c060c46e60b62c72b74012d1a4cd68"
@@ -2942,6 +2976,11 @@ node-rsa@^0.4.2:
   integrity sha1-1jkXKewWqDDtWjgEKzFX0tXXJTA=
   dependencies:
     asn1 "0.2.3"
+
+node-xmllint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-xmllint/-/node-xmllint-1.0.0.tgz#f680457eb0166a3d06996f1242d34d47000fe55b"
+  integrity sha1-9oBFfrAWaj0GmW8SQtNNRwAP5Vs=
 
 nopt@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
this allows installation to succeed even if javac is not present
also remove redundant 'npm install's from preinstall script

relates to issue #258 