### PR TITLE
fix: add xmlns:xs and nmlns:xsi attribute

### DIFF
--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -235,7 +235,7 @@ const libSaml = () => {
     */
     attributeStatementBuilder(attributes: LoginResponseAttribute[]): string {
       const attr = attributes.map(({ name, nameFormat, valueTag, valueXsiType, valueXmlnsXs, valueXmlnsXsi }) => {
-        return `<saml:Attribute Name="${name}" NameFormat="${nameFormat}"><saml:AttributeValue xmlns:xs="${valueXmlnsXs}" xmlns:xsi="${valueXmlnsXsi}" xsi:type="${valueXsiType}">{${tagging('attr', valueTag)}}</saml:AttributeValue></saml:Attribute>`;
+        return `<saml:Attribute Name="${name}" NameFormat="${nameFormat}"><saml:AttributeValue ${valueXmlnsXs ? `xmlns:xs="${valueXmlnsXs}" ` : ``}${valueXmlnsXsi ? `xmlns:xsi="${valueXmlnsXsi}" ` : ``}xsi:type="${valueXsiType}">{${tagging('attr', valueTag)}}</saml:AttributeValue></saml:Attribute>`;
       }).join('');
       return `<saml:AttributeStatement>${attr}</saml:AttributeStatement>`;
     },

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -54,6 +54,8 @@ export interface LoginResponseAttribute {
   nameFormat: string; //
   valueXsiType: string; //
   valueTag: string;
+  valueXmlnsXs?: string;
+  valueXmlnsXsi?: string;
 }
 
 export interface BaseSamlTemplate {
@@ -232,8 +234,8 @@ const libSaml = () => {
     * @return {string}
     */
     attributeStatementBuilder(attributes: LoginResponseAttribute[]): string {
-      const attr = attributes.map(({ name, nameFormat, valueTag, valueXsiType }) => {
-        return `<saml:Attribute Name="${name}" NameFormat="${nameFormat}"><saml:AttributeValue xsi:type="${valueXsiType}">{${tagging('attr', valueTag)}}</saml:AttributeValue></saml:Attribute>`;
+      const attr = attributes.map(({ name, nameFormat, valueTag, valueXsiType, valueXmlnsXs, valueXmlnsXsi }) => {
+        return `<saml:Attribute Name="${name}" NameFormat="${nameFormat}"><saml:AttributeValue xmlns:xs="${valueXmlnsXs}" xmlns:xsi="${valueXmlnsXsi}" xsi:type="${valueXsiType}">{${tagging('attr', valueTag)}}</saml:AttributeValue></saml:Attribute>`;
       }).join('');
       return `<saml:AttributeStatement>${attr}</saml:AttributeStatement>`;
     },

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -235,7 +235,9 @@ const libSaml = () => {
     */
     attributeStatementBuilder(attributes: LoginResponseAttribute[]): string {
       const attr = attributes.map(({ name, nameFormat, valueTag, valueXsiType, valueXmlnsXs, valueXmlnsXsi }) => {
-        return `<saml:Attribute Name="${name}" NameFormat="${nameFormat}"><saml:AttributeValue ${valueXmlnsXs ? `xmlns:xs="${valueXmlnsXs}" ` : ``}${valueXmlnsXsi ? `xmlns:xsi="${valueXmlnsXsi}" ` : ``}xsi:type="${valueXsiType}">{${tagging('attr', valueTag)}}</saml:AttributeValue></saml:Attribute>`;
+        const defaultValueXmlnsXs = 'http://www.w3.org/2001/XMLSchema'
+        const defaultValueXmlnsXsi = 'http://www.w3.org/2001/XMLSchema-instance'
+        return `<saml:Attribute Name="${name}" NameFormat="${nameFormat}"><saml:AttributeValue xmlns:xs="${valueXmlnsXs ? valueXmlnsXs : defaultValueXmlnsXs}" xmlns:xsi="${valueXmlnsXsi ? valueXmlnsXsi : defaultValueXmlnsXsi}" xsi:type="${valueXsiType}">{${tagging('attr', valueTag)}}</saml:AttributeValue></saml:Attribute>`;
       }).join('');
       return `<saml:AttributeStatement>${attr}</saml:AttributeStatement>`;
     },

--- a/test/index.ts
+++ b/test/index.ts
@@ -285,9 +285,9 @@ test('getAssertionConsumerService with two bindings', t => {
       name: 'email',
       valueTag: 'user.email',
       nameFormat: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic',
-      valueXsiType: 'xs:string',
+      valueXsiType: 'xs:string'
     }];
-    const expectedStatement = '<saml:AttributeStatement><saml:Attribute Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xsi:type="xs:string">{attrUserEmail}</saml:AttributeValue></saml:Attribute></saml:AttributeStatement>';
+    const expectedStatement = '<saml:AttributeStatement><saml:Attribute Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">{attrUserEmail}</saml:AttributeValue></saml:Attribute></saml:AttributeStatement>';
 
     t.is(libsaml.attributeStatementBuilder(attributes), expectedStatement);
   });
@@ -303,7 +303,7 @@ test('getAssertionConsumerService with two bindings', t => {
       nameFormat: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic',
       valueXsiType: 'xs:string',
     }];
-    const expectedStatement = '<saml:AttributeStatement><saml:Attribute Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xsi:type="xs:string">{attrUserEmail}</saml:AttributeValue></saml:Attribute><saml:Attribute Name="firstname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xsi:type="xs:string">{attrUserFirstname}</saml:AttributeValue></saml:Attribute></saml:AttributeStatement>';
+    const expectedStatement = '<saml:AttributeStatement><saml:Attribute Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">{attrUserEmail}</saml:AttributeValue></saml:Attribute><saml:Attribute Name="firstname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">{attrUserFirstname}</saml:AttributeValue></saml:Attribute></saml:AttributeStatement>';
     t.is(libsaml.attributeStatementBuilder(attributes), expectedStatement);
   });
 })();


### PR DESCRIPTION
 **Without** the optional dependency libxml-mt installed. If these two attributes are not provided the xml validator will complain about xml namespace problem. So we'd better add these two attribute to saml attribute value as optional attributes.

```javascript
  let idp = IdentityProvider({
    metadata:IdPMetadata,
    encPrivateKey:encPrivateKey,
    privateKey:privateKey,
    encPrivateKeyPass:encPrivateKeyPass,
    privateKeyPass:privateKeyPass,
    loginResponseTemplate: {
      context:
        '<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" IssueInstant="{IssueInstant}" Destination="{Destination}"><saml:Issuer>{Issuer}</saml:Issuer><samlp:Status><samlp:StatusCode Value="{StatusCode}"/></samlp:Status><saml:Assertion ID="{AssertionID}" Version="2.0" IssueInstant="{IssueInstant}" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"><saml:Issuer>{Issuer}</saml:Issuer><saml:Subject><saml:NameID Format="{NameIDFormat}">{NameID}</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="{SubjectConfirmationDataNotOnOrAfter}" Recipient="{SubjectRecipient}"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="{ConditionsNotBefore}" NotOnOrAfter="{ConditionsNotOnOrAfter}"><saml:AudienceRestriction><saml:Audience>{Audience}</saml:Audience></saml:AudienceRestriction></saml:Conditions>{AttributeStatement}</saml:Assertion></samlp:Response>',
      attributes: [
        {
          name: 'email',
          valueTag: 'user.email',
          nameFormat: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic',
          valueXsiType: 'xs:string',
          valueXmlnsXs: 'http://www.w3.org/2001/XMLSchema',
          valueXmlnsXsi: 'http://www.w3.org/2001/XMLSchema-instance',
        },
```
