### PR TITLE
use native xmllint for schema validation on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "camelcase": "^5.2.0",
     "deflate-js": "^0.2.3",
+    "global": "^4.3.2",
     "node-forge": "^0.7.5",
     "node-rsa": "^0.4.2",
     "uuid": "^3.3.2",
@@ -46,7 +47,8 @@
   "optionalDependencies": {
     "@authenio/xml-encryption": "^0.11.2",
     "libxml-xsd": "^0.5.2",
-    "node-xmllint": "^1.0.0"
+    "node-xmllint": "^1.0.0",
+    "validate-with-xmllint": "^1.0.2"
   },
   "devDependencies": {
     "@types/camelcase": "^5.2.0",
@@ -58,6 +60,6 @@
     "coveralls": "^3.0.2",
     "nyc": "^11.9.0",
     "tslint": "^5.12.1",
-    "typescript": "^3.3.3333"
+    "typescript": "^3.4.5"
   }
 }

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -4,7 +4,8 @@ import * as path from 'path';
 enum SchemaValidators {
   JAVAC = '@authenio/xsd-schema-validator',
   LIBXML = 'libxml-xsd',
-  XMLLINT = 'node-xmllint'
+  XMLLINT = 'node-xmllint',
+	NATIVEXMLLINT = 'validate-with-xmllint'
 }
 
 export interface SchemaValidator {
@@ -139,6 +140,29 @@ const getValidatorModule: GetValidatorModuleSpec = async () => {
         });
       }
     };
+  }
+
+  if (selectedValidator === SchemaValidators.NATIVEXMLLINT) {
+
+		const mod = await import (SchemaValidators.NATIVEXMLLINT);
+
+		return {
+			validate: (xml: string) => {
+				return new Promise((resolve, reject) => {
+
+					process.chdir(path.resolve(__dirname, '../schemas'));
+
+					mod.validateXMLWithXSD(xml, xsd)
+					.then(function(result) {
+						return resolve('SUCCESS_VALIDATE_XML');
+					}, function(err) {
+						console.error('[ERROR] validateXML', err);
+						return reject('ERR_INVALID_XML');
+					})
+
+				});
+			}
+		};
   }
 
   // allow to skip the validate function if it's in development or test mode if no schema validator is provided


### PR DESCRIPTION
Using  version 2.5.0 we were having problems with java causing ENOMEM, libxml-xsd won't compile against node 10.15 so we tried using node-xmllint for schema validation. The server would crash unexpectedly without a stack trace.  So, I have been testing with validate-with-xmllint, which uses native OS xmllint (via libxml2-utils package for debian)..instead of the node-xmllint which is an Emscripten port of xmllint.    node-xmllint hasn't been updated in 3 years and libxml-xsd hasn't been updated in 3 years either.    Validate-with-xmllint is typescript, and it's only 2 months old but the best part is that its a very lightweight wrapper around the system xmllint so there is very little code to maintain.    The xmllint on the system is maintained by the Linux OS developers and the GNOME project which both have very active development teams. 

Testing:
Tested on Debian after installing libxml2-utils and removing all other SchemaValidators. 