### PR TITLE
Logout request template and Logout NameID format consistency

### DIFF
--- a/src/binding-post.ts
+++ b/src/binding-post.ts
@@ -88,6 +88,8 @@ async function base64LoginResponse(requestInfo: any = {}, entity: any, user: any
     idp: entity.idp.entityMeta,
     sp: entity.sp.entityMeta,
   };
+  const nameIDFormat = idpSetting.nameIDFormat;
+  const selectedNameIDFormat = Array.isArray(nameIDFormat) ? nameIDFormat[0] : nameIDFormat;
   if (metadata && metadata.idp && metadata.sp) {
     const base = metadata.sp.getAssertionConsumerService(binding.post);
     let rawSamlResponse: string;
@@ -113,7 +115,7 @@ async function base64LoginResponse(requestInfo: any = {}, entity: any, user: any
       ConditionsNotBefore: now,
       ConditionsNotOnOrAfter: fiveMinutesLater,
       SubjectConfirmationDataNotOnOrAfter: fiveMinutesLater,
-      NameIDFormat: namespace.format[idpSetting.logoutNameIDFormat] || namespace.format.emailAddress,
+      NameIDFormat: selectedNameIDFormat,
       NameID: user.email || '',
       InResponseTo: get(requestInfo, 'extract.request.id', ''),
       AuthnStatement: '',
@@ -214,7 +216,8 @@ async function base64LoginResponse(requestInfo: any = {}, entity: any, user: any
 function base64LogoutRequest(user, referenceTagXPath, entity, customTagReplacement?: (template: string) => BindingContext): BindingContext {
   const metadata = { init: entity.init.entityMeta, target: entity.target.entityMeta };
   const initSetting = entity.init.entitySetting;
-  let id: string = '';
+  const nameIDFormat = initSetting.nameIDFormat;
+  const selectedNameIDFormat = Array.isArray(nameIDFormat) ? nameIDFormat[0] : nameIDFormat;  let id: string = '';
   if (metadata && metadata.init && metadata.target) {
     let rawSamlRequest: string;
     if (initSetting.logoutRequestTemplate && customTagReplacement) {
@@ -229,7 +232,7 @@ function base64LogoutRequest(user, referenceTagXPath, entity, customTagReplaceme
         Issuer: metadata.init.getEntityID(),
         IssueInstant: new Date().toISOString(),
         EntityID: metadata.init.getEntityID(),
-        NameIDFormat: namespace.format[initSetting.logoutNameIDFormat] || namespace.format.transient,
+        NameIDFormat: selectedNameIDFormat,
         NameID: user.logoutNameID,
       };
       rawSamlRequest = libsaml.replaceTagsByValue(libsaml.defaultLogoutRequestTemplate.context, tvalue);

--- a/src/binding-redirect.ts
+++ b/src/binding-redirect.ts
@@ -125,6 +125,9 @@ function logoutRequestRedirectURL(user, entity, relayState?: string, customTagRe
   const metadata = { init: entity.init.entityMeta, target: entity.target.entityMeta };
   const initSetting = entity.init.entitySetting;
   let id: string = initSetting.generateID();
+  const nameIDFormat = initSetting.nameIDFormat;
+  const selectedNameIDFormat = Array.isArray(nameIDFormat) ? nameIDFormat[0] : nameIDFormat;
+  
   if (metadata && metadata.init && metadata.target) {
     const base = metadata.target.getSingleLogoutService(binding.redirect);
     let rawSamlRequest: string = '';
@@ -134,7 +137,7 @@ function logoutRequestRedirectURL(user, entity, relayState?: string, customTagRe
       EntityID: metadata.init.getEntityID(),
       Issuer: metadata.init.getEntityID(),
       IssueInstant: new Date().toISOString(),
-      NameIDFormat: namespace.format[initSetting.logoutNameIDFormat] || namespace.format.emailAddress,
+      NameIDFormat: selectedNameIDFormat,
       NameID: user.logoutNameID,
       SessionIndex: user.sessionIndex,
     };

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -136,7 +136,7 @@ const libSaml = () => {
   * @type {LogoutRequestTemplate}
   */
   const defaultLogoutRequestTemplate = {
-    context: '<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" IssueInstant="{IssueInstant}" Destination="{Destination}"><saml:Issuer>{Issuer}</saml:Issuer><saml:NameID SPNameQualifier="{EntityID}" Format="{NameIDFormat}">{NameID}</saml:NameID></samlp:LogoutRequest>',
+    context: '<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" IssueInstant="{IssueInstant}" Destination="{Destination}"><saml:Issuer>{Issuer}</saml:Issuer><saml:NameID Format="{NameIDFormat}">{NameID}</saml:NameID></samlp:LogoutRequest>',
   };
   /**
   * @desc Default login response template


### PR DESCRIPTION
1. Remove SPNameAualifier attributes from `defaultLogoutRequestTemplate`
2. Change logout nameId format to take nameIDFormat from entity settings. 