### PR TITLE
Fallback to object settings if metadata is not specifying NameIDFormat

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -80,7 +80,7 @@ export default class Entity {
         // setting with metadata has higher precedence 
         this.entitySetting.authnRequestsSigned = this.entityMeta.isAuthnRequestSigned();
         this.entitySetting.wantAssertionsSigned = this.entityMeta.isWantAssertionsSigned();
-        this.entitySetting.nameIDFormat = this.entityMeta.getNameIDFormat();
+        this.entitySetting.nameIDFormat = this.entityMeta.getNameIDFormat() || this.entitySetting.nameIDFormat;
         break;
       default:
         throw new Error('ERR_UNDEFINED_ENTITY_TYPE');


### PR DESCRIPTION
Right now if SP metadata is not specifying `NameIDFormat` and `ServiceProvider` object will have `nameIDFormat` set to null even though `ServiceProvider` was initialized with a value.

Proposal is to fallback to `ServiceProvider` settings if metadata is not specifying.