### PR TITLE
added error time duration of -5 seconds 

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -19,7 +19,9 @@ function verifyTime(utcNotBefore?: string, utcNotOnOrAfter?: string): boolean {
 
   notBeforeLocal = new Date(utcNotBefore!);
   notOnOrAfterLocal = new Date(utcNotOnOrAfter!);
-  return +notBeforeLocal <= +now && now < notOnOrAfterLocal;
+
+  //Here setting time diff b/w notBeforeLocal and now can be greater than -5 seconds. This comes in the scenario when there is a mismatch of time between sp and idp server timings which result in ERR_SUBJECT_VALIDATION error
+  return +now - +notBeforeLocal > -5000  && now < notOnOrAfterLocal;
 }
 
 export {


### PR DESCRIPTION
I am allowing -5 seconds of error duration while comparing now and notBeforeLocal time.

The reason why I am doing this mainly because I have faced this issue of server time is not in sync with SP and IDP server because of which SAML response conditions fail. So, I wanted to allow a error window of -5 seconds so that validation function never fails for these type of situations.

You can also set a variable for setting this error window which can be set which initiating samlify.