### PR TITLE
Fixed typo in loginResponseFields

### DIFF
--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -98,7 +98,7 @@ export const logoutResponseStatusFields = [
   }
 ];
 
-export const loginResponseFields: ((asserion: any) => ExtractorFields) = assertion => [
+export const loginResponseFields: ((assertion: any) => ExtractorFields) = assertion => [
   {
     key: 'conditions',
     localPath: ['Assertion', 'Conditions'],


### PR DESCRIPTION
I think this is a typo in the parameter name.