### PR TITLE
Add missing property to sp settings type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export type ServiceProviderSettings = {
   privateKey?: string | Buffer;
   privateKeyPass?: string;
   isAssertionEncrypted?: boolean;
+  requestSignatureAlgorithm?: string;
   encPrivateKey?: string | Buffer;
   encPrivateKeyPass?: string | Buffer;
   assertionConsumerService?: Array<{ Binding: string, Location: string }>;


### PR DESCRIPTION
It should be possible to set the `requestSignatureAlgorithm` setting and overwrite the default value. As far as I can see this is just a problem with the `ServiceProviderSettings` type.