### PR TITLE
Fix Response Without Cert

### DIFF
--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -366,7 +366,8 @@ const libSaml = () => {
           // normalise the certificate string
           metadataCert = metadataCert.map(utility.normalizeCerString);
 
-          if (metadataCert.length === 0) {
+          // no certificate in response or metadata
+          if (metadataCert.length === 0 && metadataCert.length === 0) {
             throw new Error('NO_SELECTED_CERTIFICATE');
           }
 

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -366,11 +366,11 @@ const libSaml = () => {
           // normalise the certificate string
           metadataCert = metadataCert.map(utility.normalizeCerString);
 
-          if (certificateNode.length === 0) {
+          if (metadataCert.length === 0) {
             throw new Error('NO_SELECTED_CERTIFICATE');
           }
 
-          // no certificate node in response
+          // certificate node in response
           if (certificateNode.length !== 0) {
             const x509CertificateData = certificateNode[0].firstChild.data;
             const x509Certificate = utility.normalizeCerString(x509CertificateData);
@@ -386,6 +386,9 @@ const libSaml = () => {
 
             sig.keyInfoProvider = new this.getKeyInfo(x509Certificate);
 
+          } else {
+            // no certificate node in response so just use the first cert in metadata
+            sig.keyInfoProvider = new this.getKeyInfo(metadataCert[0]);
           }
 
         } 


### PR DESCRIPTION
Needed this for a client setup. Current implementation seems to only work if there is a certificate in the response. This changes it to fallback to use the first certificate in the metadata if none are provided via the response. Would appreciate some guidance in setting up tests for this.

Fixes #374 