### PR TITLE
throw when cert is null

### DIFF
--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -357,6 +357,9 @@ const libSaml = () => {
           const certificateNode = select(".//*[local-name(.)='X509Certificate']", signatureNode) as any;
           // certificate in metadata
           let metadataCert: any = opts.metadata.getX509Certificate(certUse.signing);
+          if (!metadataCert) {
+            throw new Error('INVALID_CERTIFICATE_PROVIDED')
+          }
           // flattens the nested array of Certificates from each KeyDescriptor
           if (Array.isArray(metadataCert)) {
             metadataCert = flattenDeep(metadataCert);


### PR DESCRIPTION
Related to: https://github.com/tngan/samlify/issues/222
I had a case where our saved IdP cert was invalid & when the correct cert came back in the response the cert was null.
The error message received was `Cannot read property 'map' of null`, which wasn't helpful.
This throws an error message which is a bit more helpful.