### PR TITLE
Filter out empty node when extracting attributes from xml metadata

### DIFF
--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -253,7 +253,7 @@ export function extract(context: string, fields) {
         index: ['Name'],
         attributePath: ['AttributeValue'],
         attributes: []
-      } 
+      }
     */
     if (index && attributePath) {
       // find the index in localpath
@@ -309,7 +309,7 @@ export function extract(context: string, fields) {
         value = node[0].toString();
       }
       if (node.length > 1) {
-        value = node.map(n => n.toString()); 
+        value = node.map(n => n.toString());
       }
       return {
         ...result,
@@ -330,7 +330,7 @@ export function extract(context: string, fields) {
       const childXPath = `${buildAbsoluteXPath([last(localPath)])}${attributeXPath}`;
       const attributeValues = baseNode.map((node: string) => {
         const nodeDoc = new dom().parseFromString(node);
-        const values = select(childXPath, nodeDoc).reduce((r: any, n: Attr) => { 
+        const values = select(childXPath, nodeDoc).reduce((r: any, n: Attr) => {
           r[camelCase(n.name)] = n.value;
           return r;
         }, {});
@@ -373,7 +373,8 @@ export function extract(context: string, fields) {
         attributeValue = select(fullPath, targetDoc);
       }
       if (node.length > 1) {
-        attributeValue = node.map((n: Node) => n.firstChild!.nodeValue);
+        attributeValue = node.filter((n: Node) => n.firstChild)
+          .map((n: Node) => n.firstChild!.nodeValue);
       }
       return {
         ...result,


### PR DESCRIPTION
When a node in xml metadata is empty, for example
``` 
        <md:KeyDescriptor use="signing">
            <ds:KeyInfo>
                <ds:X509Data>
                    <ds:X509Certificate></ds:X509Certificate>
                </ds:X509Data>
            </ds:KeyInfo>
        </md:KeyDescriptor>
        <md:KeyDescriptor use="encryption">
            <ds:KeyInfo>
                <ds:X509Data>
                    <ds:X509Certificate></ds:X509Certificate>
                </ds:X509Data>
            </ds:KeyInfo>
        </md:KeyDescriptor>
```

The piece of code below throwing this error `TypeError: Cannot read property 'nodeValue' of null` at `samlify/build/src/extractor.js:347:41`
```        
         if (attributes.length === 0) {
            var attributeValue = null;
            var node = xpath_1.select(baseXPath, targetDoc);
            if (node.length === 1) {
                var fullPath = "string(" + baseXPath + attributeXPath + ")";
                attributeValue = xpath_1.select(fullPath, targetDoc);
            }
            if (node.length > 1) {
                attributeValue = node.map(function (n) {
                    return n.firstChild.nodeValue;
                });
            }
            return __assign({}, result, (_f = {}, _f[key] = attributeValue, _f));
        }
```
