### PR TITLE
Feature/Login Request Relay State

### DIFF
--- a/src/binding-redirect.ts
+++ b/src/binding-redirect.ts
@@ -72,10 +72,11 @@ function buildRedirectURL(opts: BuildRedirectConfig) {
 * @param  {function} customTagReplacement      used when developers have their own login response template
 * @return {string} redirect URL
 */
-function loginRequestRedirectURL(entity: { idp: Idp, sp: Sp }, customTagReplacement?: (template: string) => BindingContext): BindingContext {
+function loginRequestRedirectURL(entity: { idp: Idp, sp: Sp, relayState?: string }, customTagReplacement?: (template: string) => BindingContext): BindingContext {
 
   const metadata: any = { idp: entity.idp.entityMeta, sp: entity.sp.entityMeta };
   const spSetting: any = entity.sp.entitySetting;
+  const relayState = entity.relayState ?? entity.sp.entitySetting.relayState;
   let id: string = '';
 
   if (metadata && metadata.idp && metadata.sp) {
@@ -108,7 +109,7 @@ function loginRequestRedirectURL(entity: { idp: Idp, sp: Sp }, customTagReplacem
         isSigned: metadata.sp.isAuthnRequestSigned(),
         entitySetting: spSetting,
         baseUrl: base,
-        relayState: spSetting.relayState,
+        relayState,
       }),
     };
   }

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -54,7 +54,8 @@ export class ServiceProvider extends Entity {
   */
   public createLoginRequest(
     idp: IdentityProvider,
-    binding = 'redirect',
+    binding: 'redirect' | 'post' = 'redirect',
+    relayState?: string,
     customTagReplacement?: (template: string) => BindingContext,
   ): BindingContext | PostBindingContext {
     const nsBinding = namespace.binding;
@@ -64,14 +65,14 @@ export class ServiceProvider extends Entity {
     }
 
     if (protocol === nsBinding.redirect) {
-      return redirectBinding.loginRequestRedirectURL({ idp, sp: this }, customTagReplacement);
+      return redirectBinding.loginRequestRedirectURL({ idp, sp: this, relayState }, customTagReplacement);
     }
 
     if (protocol === nsBinding.post) {
       const context = postBinding.base64LoginRequest("/*[local-name(.)='AuthnRequest']", { idp, sp: this }, customTagReplacement);
       return {
         ...context,
-        relayState: this.entitySetting.relayState,
+        relayState: relayState ?? this.entitySetting.relayState,
         entityEndpoint: idp.entityMeta.getSingleSignOnService(binding) as string,
         type: 'SAMLRequest',
       };


### PR DESCRIPTION
Add support for relayState when creating the SAML request using `createLoginRequest`. This is essentially the same implementation that was done in #257 but without the other changes not related to relay state. This would make it easier to use relay state in a backwards compatible way.