### PR TITLE
Fixes issue with SAMLSignature method not using default transformations

### DIFF
--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -322,7 +322,7 @@ const libSaml = () => {
       if (referenceTagXPath) {
         sig.addReference(
           referenceTagXPath,
-          opts.transformationAlgorithms,
+          transformationAlgorithms,
           getDigestMethod(signatureAlgorithm)
         );
       }


### PR DESCRIPTION
This seems to be a bug where the method sets up a default array of transformations when none is passed in the options but then this code ignores the defaults and uses the ones from the options passed which could be undefined.  The addReference then possibly passes an undefined transformations which xml-crypto library only adds 'http://www.w3.org/2001/10/xml-exc-c14n#' instead of 'http://www.w3.org/2001/10/xml-exc-c14n#' and 'http://www.w3.org/2000/09/xmldsig#enveloped-signature' defined in this codebase's constructSAMLSignature.