### PR TITLE
Allow arrays of certs to be provided 

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -16,7 +16,7 @@ export function getContext() {
 export function setSchemaValidator(params: ValidatorContext) {
 
   if (typeof params.validate !== 'function') {
-    throw new Error('validate must be a callback function having one arguemnt as xml input');
+    throw new Error('validate must be a callback function having one argument as xml input');
   }
 
   // assign the validate function to the context

--- a/src/binding-post.ts
+++ b/src/binding-post.ts
@@ -8,7 +8,6 @@ import { wording, namespace, StatusCode } from './urn';
 import { BindingContext } from './entity';
 import libsaml from './libsaml';
 import utility, { get } from './utility';
-import { LogoutResponseTemplate } from './libsaml';
 
 const binding = wording.binding;
 
@@ -145,7 +144,7 @@ async function base64LoginResponse(requestInfo: any = {}, entity: any, user: any
         ...config,
         rawSamlMessage: rawSamlResponse,
         transformationAlgorithms: spSetting.transformationAlgorithms,
-        referenceTagXPath: "/*[local-name(.)='Response']/*[local-name(.)='Assertion']", 
+        referenceTagXPath: "/*[local-name(.)='Response']/*[local-name(.)='Assertion']",
         signatureConfig: {
           prefix: 'ds',
           location: { reference: "/*[local-name(.)='Response']/*[local-name(.)='Assertion']/*[local-name(.)='Issuer']", action: 'after' },
@@ -315,7 +314,7 @@ function base64LogoutResponse(requestInfo: any, entity: any, customTagReplacemen
               reference: "/*[local-name(.)='LogoutResponse']/*[local-name(.)='Issuer']",
               action: 'after'
             }
-          } 
+          }
         }),
       };
     }

--- a/src/binding-simplesign.ts
+++ b/src/binding-simplesign.ts
@@ -39,7 +39,7 @@ function pvPair(param: string, value: string, first?: boolean): string {
 }
 /**
 * @private
-* @desc Refractored part of simple signature generation for login/logout request
+* @desc Refactored part of simple signature generation for login/logout request
 * @param  {string} type
 * @param  {string} rawSamlRequest
 * @param  {object} entitySetting
@@ -61,10 +61,10 @@ function buildSimpleSignature(opts: BuildSimpleSignConfig) : string {
   const sigAlg = pvPair(urlParams.sigAlg, entitySetting.requestSignatureAlgorithm);
   const octetString = context + relayState + sigAlg;
   return libsaml.constructMessageSignature(
-    queryParam + '=' + octetString, 
-    entitySetting.privateKey, 
-    entitySetting.privateKeyPass, 
-    undefined, 
+    queryParam + '=' + octetString,
+    entitySetting.privateKey,
+    entitySetting.privateKeyPass,
+    undefined,
     entitySetting.requestSignatureAlgorithm
   ).toString();
 }

--- a/src/entity-idp.ts
+++ b/src/entity-idp.ts
@@ -20,14 +20,14 @@ import { isString } from './utility';
 import { BindingContext } from './entity';
 
 /**
- * Identity prvider can be configured using either metadata importing or idpSetting
+ * Identity provider can be configured using either metadata importing or idpSetting
  */
 export default function(props: IdentityProviderSettings) {
   return new IdentityProvider(props);
 }
 
 /**
- * Identity prvider can be configured using either metadata importing or idpSetting
+ * Identity provider can be configured using either metadata importing or idpSetting
  */
 export class IdentityProvider extends Entity {
 

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -1,4 +1,4 @@
-import { inflateString, base64Decode, isNonEmptyArray } from './utility';
+import { inflateString, base64Decode } from './utility';
 import { verifyTime } from './validator';
 import libsaml from './libsaml';
 import {
@@ -19,7 +19,6 @@ import {
   MessageSignatureOrder,
   StatusCode
 } from './urn';
-import simpleSignBinding from './binding-simplesign';
 
 const bindDict = wording.binding;
 const urlParams = wording.urlParams;
@@ -110,7 +109,7 @@ async function redirectFlow(options): Promise<FlowResult>  {
       return Promise.reject('ERR_MISSING_SIG_ALG');
     }
 
-    // put the below two assignemnts into verifyMessageSignature function
+    // put the below two assignments into verifyMessageSignature function
     const base64Signature = Buffer.from(decodeURIComponent(signature), 'base64');
     const decodeSigAlg = decodeURIComponent(sigAlg);
 
@@ -125,7 +124,7 @@ async function redirectFlow(options): Promise<FlowResult>  {
   }
 
   /**
-   *  Validation part: validate the context of response after signature is verified and decrpyted (optional)
+   *  Validation part: validate the context of response after signature is verified and decrypted (optional)
    */
   const issuer = targetEntityMetadata.getEntityID();
   const extractedProperties = parseResult.extract;
@@ -207,7 +206,7 @@ async function postFlow(options): Promise<FlowResult> {
   // check status based on different scenarios
   await checkStatus(samlContent, parserType);
 
-  // verify the signatures (the repsonse is encrypted then signed, then verify first then decrypt)
+  // verify the signatures (the response is encrypted then signed, then verify first then decrypt)
   if (
     checkSignature &&
     from.entitySetting.messageSigningOrder === MessageSignatureOrder.ETS
@@ -227,7 +226,7 @@ async function postFlow(options): Promise<FlowResult> {
     extractorFields = getDefaultExtractorFields(parserType, result[1]);
   }
 
-  // verify the signatures (the repsonse is signed then encrypted, then decrypt first then verify)
+  // verify the signatures (the response is signed then encrypted, then decrypt first then verify)
   if (
     checkSignature &&
     from.entitySetting.messageSigningOrder === MessageSignatureOrder.STE
@@ -246,7 +245,7 @@ async function postFlow(options): Promise<FlowResult> {
   };
 
   /**
-   *  Validation part: validate the context of response after signature is verified and decrpyted (optional)
+   *  Validation part: validate the context of response after signature is verified and decrypted (optional)
    */
   const targetEntityMetadata = from.entityMeta;
   const issuer = targetEntityMetadata.getEntityID();
@@ -355,7 +354,7 @@ async function postSimpleSignFlow(options): Promise<FlowResult> {
       return Promise.reject('ERR_MISSING_SIG_ALG');
     }
 
-    // put the below two assignemnts into verifyMessageSignature function
+    // put the below two assignments into verifyMessageSignature function
     const base64Signature = Buffer.from(signature, 'base64');
 
     const verified = libsaml.verifyMessageSignature(targetEntityMetadata, octetString, base64Signature, sigAlg);
@@ -369,7 +368,7 @@ async function postSimpleSignFlow(options): Promise<FlowResult> {
   }
 
   /**
-   *  Validation part: validate the context of response after signature is verified and decrpyted (optional)
+   *  Validation part: validate the context of response after signature is verified and decrypted (optional)
    */
   const issuer = targetEntityMetadata.getEntityID();
   const extractedProperties = parseResult.extract;

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -175,8 +175,8 @@ const libSaml = () => {
     context: '<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" IssueInstant="{IssueInstant}" Destination="{Destination}" InResponseTo="{InResponseTo}"><saml:Issuer>{Issuer}</saml:Issuer><samlp:Status><samlp:StatusCode Value="{StatusCode}"/></samlp:Status><saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{AssertionID}" Version="2.0" IssueInstant="{IssueInstant}"><saml:Issuer>{Issuer}</saml:Issuer><saml:Subject><saml:NameID Format="{NameIDFormat}">{NameID}</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="{SubjectConfirmationDataNotOnOrAfter}" Recipient="{SubjectRecipient}" InResponseTo="{InResponseTo}"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="{ConditionsNotBefore}" NotOnOrAfter="{ConditionsNotOnOrAfter}"><saml:AudienceRestriction><saml:Audience>{Audience}</saml:Audience></saml:AudienceRestriction></saml:Conditions>{AuthnStatement}{AttributeStatement}</saml:Assertion></samlp:Response>',
     attributes: [],
     additionalTemplates: {
-      "attributeStatementTemplate": defaultAttributeStatementTemplate,
-      "attributeTemplate": defaultAttributeTemplate
+      'attributeStatementTemplate': defaultAttributeStatementTemplate,
+      'attributeTemplate': defaultAttributeTemplate
     }
   };
   /**
@@ -252,7 +252,7 @@ const libSaml = () => {
     defaultLogoutResponseTemplate,
 
     /**
-    * @desc Repalce the tag (e.g. {tag}) inside the raw XML
+    * @desc Replace the tag (e.g. {tag}) inside the raw XML
     * @param  {string} rawXML      raw XML string used to do keyword replacement
     * @param  {array} tagValues    tag values
     * @return {string}
@@ -266,8 +266,8 @@ const libSaml = () => {
     /**
     * @desc Helper function to build the AttributeStatement tag
     * @param  {LoginResponseAttribute} attributes    an array of attribute configuration
-    * @param  {AttributeTemplate} attributeTemplate    the attribut tag template to be used
-    * @param  {AttributeStatementTemplate} attributeStatementTemplate    the attributStatement tag template to be used
+    * @param  {AttributeTemplate} attributeTemplate    the attribute tag template to be used
+    * @param  {AttributeStatementTemplate} attributeStatementTemplate    the attributeStatement tag template to be used
     * @return {string}
     */
     attributeStatementBuilder(
@@ -351,7 +351,6 @@ const libSaml = () => {
     /**
     * @desc Verify the XML signature
     * @param  {string} xml xml
-    * @param  {signature} signature context of XML signature
     * @param  {SignatureVerifierOptions} opts cert declares the X509 certificate
     * @return {boolean} verification result
     */
@@ -639,7 +638,7 @@ const libSaml = () => {
             return resolve(utility.base64Encode(doc.toString()));
           });
         } else {
-          return resolve(utility.base64Encode(xml)); // No need to do encrpytion
+          return resolve(utility.base64Encode(xml)); // No need to do encryption
         }
       });
     },

--- a/src/metadata-idp.ts
+++ b/src/metadata-idp.ts
@@ -7,7 +7,7 @@ import Metadata, { MetadataInterface } from './metadata';
 import { MetadataIdpOptions, MetadataIdpConstructor } from './types';
 import { namespace } from './urn';
 import libsaml from './libsaml';
-import { isNonEmptyArray, isString } from './utility';
+import { castArrayOpt, isNonEmptyArray, isString } from './utility';
 import xml from 'xml';
 
 export interface IdpMetadataInterface extends MetadataInterface {
@@ -46,16 +46,12 @@ export class IdpMetadata extends Metadata {
         },
       }];
 
-      if (signingCert) {
-        IDPSSODescriptor.push(libsaml.createKeySection('signing', signingCert));
-      } else {
-        //console.warn('Construct identity provider - missing signing certificate');
+      for(const cert of castArrayOpt(signingCert)) {
+        IDPSSODescriptor.push(libsaml.createKeySection('signing', cert));
       }
 
-      if (encryptCert) {
-        IDPSSODescriptor.push(libsaml.createKeySection('encryption', encryptCert));
-      } else {
-        //console.warn('Construct identity provider - missing encrypt certificate');
+      for(const cert of castArrayOpt(encryptCert)) {
+        IDPSSODescriptor.push(libsaml.createKeySection('encryption', cert));
       }
 
       if (isNonEmptyArray(nameIDFormat)) {

--- a/src/metadata-sp.ts
+++ b/src/metadata-sp.ts
@@ -7,7 +7,7 @@ import Metadata, { MetadataInterface } from './metadata';
 import { MetadataSpConstructor, MetadataSpOptions } from './types';
 import { namespace, elementsOrder as order } from './urn';
 import libsaml from './libsaml';
-import { isNonEmptyArray, isString } from './utility';
+import { castArrayOpt, isNonEmptyArray, isString } from './utility';
 import xml from 'xml';
 
 export interface SpMetadataInterface extends MetadataInterface {
@@ -80,16 +80,12 @@ export class SpMetadata extends Metadata {
         console.warn('Construct service provider - missing signatureConfig');
       }
 
-      if (signingCert) {
-        descriptors.KeyDescriptor!.push(libsaml.createKeySection('signing', signingCert).KeyDescriptor);
-      } else {
-        //console.warn('Construct service provider - missing signing certificate');
+      for(const cert of castArrayOpt(signingCert)) {
+        descriptors.KeyDescriptor!.push(libsaml.createKeySection('signing', cert).KeyDescriptor);
       }
 
-      if (encryptCert) {
-        descriptors.KeyDescriptor!.push(libsaml.createKeySection('encryption', encryptCert).KeyDescriptor);
-      } else {
-        //console.warn('Construct service provider - missing encrypt certificate');
+      for(const cert of castArrayOpt(encryptCert)) {
+        descriptors.KeyDescriptor!.push(libsaml.createKeySection('encryption', cert).KeyDescriptor);
       }
 
       if (isNonEmptyArray(nameIDFormat)) {

--- a/src/metadata-sp.ts
+++ b/src/metadata-sp.ts
@@ -36,14 +36,14 @@ export default function(meta: MetadataSpConstructor) {
 export class SpMetadata extends Metadata {
 
   /**
-  * @param  {object/string} meta (either xml string or configuation in object)
+  * @param  {object/string} meta (either xml string or configuration in object)
   * @return {object} prototypes including public functions
   */
   constructor(meta: MetadataSpConstructor) {
 
     const isFile = isString(meta) || meta instanceof Buffer;
 
-    // use object configuation instead of importing metadata file directly
+    // use object configuration instead of importing metadata file directly
     if (!isFile) {
 
       const {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -25,7 +25,7 @@ export default class Metadata implements MetadataInterface {
   meta: any;
 
   /**
-  * @param  {string | Buffer} metadata xml
+  * @param  {string | Buffer} xml
   * @param  {object} extraParse for custom metadata extractor
   */
   constructor(xml: string | Buffer, extraParse: any = []) {
@@ -140,7 +140,7 @@ export default class Metadata implements MetadataInterface {
       if (!(singleLogoutService instanceof Array)) {
         singleLogoutService = [singleLogoutService];
        }
-      const service = singleLogoutService.find(obj => obj.binding === bindType);      
+      const service = singleLogoutService.find(obj => obj.binding === bindType);
       if (service) {
         return service.location;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,8 @@ type SSOService = {
 
 export interface MetadataIdpOptions {
   entityID?: string;
-  signingCert?: string | Buffer;
-  encryptCert?: string | Buffer;
+  signingCert?: string | Buffer | (string | Buffer)[];
+  encryptCert?: string | Buffer | (string | Buffer)[];
   wantAuthnRequestsSigned?: boolean;
   nameIDFormat?: string[];
   singleSignOnService?: SSOService[];
@@ -31,8 +31,8 @@ export type MetadataIdpConstructor =
 
 export interface MetadataSpOptions {
   entityID?: string;
-  signingCert?: string | Buffer;
-  encryptCert?: string | Buffer;
+  signingCert?: string | Buffer | (string | Buffer)[];
+  encryptCert?: string | Buffer | (string | Buffer)[];
   authnRequestsSigned?: boolean;
   wantAssertionsSigned?: boolean;
   wantMessageSigned?: boolean;
@@ -81,8 +81,8 @@ export type ServiceProviderSettings = {
   signatureConfig?: SignatureConfig;
   loginRequestTemplate?: SAMLDocumentTemplate;
   logoutRequestTemplate?: SAMLDocumentTemplate;
-  signingCert?: string | Buffer;
-  encryptCert?: string | Buffer;
+  signingCert?: string | Buffer | (string | Buffer)[];
+  encryptCert?: string | Buffer | (string | Buffer)[];
   transformationAlgorithms?: string[];
   nameIDFormat?: string[];
   allowCreate?: boolean;
@@ -110,8 +110,8 @@ export type IdentityProviderSettings = {
   entityID?: string;
   privateKey?: string | Buffer;
   privateKeyPass?: string;
-  signingCert?: string | Buffer;
-  encryptCert?: string | Buffer; /** todo */
+  signingCert?: string | Buffer | (string | Buffer)[];
+  encryptCert?: string | Buffer | (string | Buffer)[];
   nameIDFormat?: string[];
   singleSignOnService?: SSOService[];
   singleLogoutService?: SSOService[];

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -201,6 +201,11 @@ export function isNonEmptyArray(a) {
   return Array.isArray(a) && a.length > 0;
 }
 
+export function castArrayOpt<T>(a?: T | T[]): T[] {
+  if (a === undefined) return []
+  return Array.isArray(a) ? a : [a]
+}
+
 export function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
   return value !== null && value !== undefined;
 }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -15,7 +15,7 @@ const BASE64_STR = 'base64';
  */
 export function zipObject(arr1: string[], arr2: any[], skipDuplicated = true) {
   return arr1.reduce((res, l, i) => {
-    
+
     if (skipDuplicated) {
       res[l] = arr2[i];
       return res;
@@ -61,19 +61,19 @@ export function uniq(input: string[]) {
   return [... set];
 }
 /**
- * @desc Alternative to lodash.get 
+ * @desc Alternative to lodash.get
  * @reference https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_get
- * @param obj 
- * @param path 
- * @param defaultValue 
+ * @param obj
+ * @param path
+ * @param defaultValue
  */
 export function get(obj, path, defaultValue) {
   return path.split('.')
   .reduce((a, c) => (a && a[c] ? a[c] : (defaultValue || null)), obj);
 }
 /**
- * @desc Check if the input is string 
- * @param {any} input 
+ * @desc Check if the input is string
+ * @param {any} input
  */
 export function isString(input: any) {
   return typeof input === 'string';
@@ -180,7 +180,7 @@ function getPublicKeyPemFromCertificate(x509Certificate: string) {
 }
 /**
 * @desc Read private key from pem-formatted string
-* @param {string | Buffer} keyString pem-formattted string
+* @param {string | Buffer} keyString pem-formatted string
 * @param {string} protected passphrase of the key
 * @return {string} string in pem format
 * If passphrase is used to protect the .pem content (recommend)

--- a/test/index.ts
+++ b/test/index.ts
@@ -331,6 +331,28 @@ test('getAssertionConsumerService with two bindings', t => {
 
 })();
 
+test('idp with multiple signing and encryption certificates', t => {
+  const localIdp = identityProvider({
+    signingCert: [
+      readFileSync('./test/key/sp/cert.cer'),
+      readFileSync('./test/key/sp/cert2.cer').toString(),
+    ],
+    encryptCert: [
+      readFileSync('./test/key/idp/encryptionCert.cer'),
+      readFileSync('./test/key/idp/encryptionCert.cer').toString(),
+    ]
+  })
+
+  const signingCertificate = localIdp.entityMeta.getX509Certificate('signing');
+  const encryptionCertificate = localIdp.entityMeta.getX509Certificate('encryption');
+
+  t.is(Array.isArray(signingCertificate), true);
+  t.is(signingCertificate.length, 2);
+
+  t.is(Array.isArray(encryptionCertificate), true);
+  t.is(encryptionCertificate.length, 2);
+})
+
 test('verify time with and without drift tolerance', t => {
   
   const now = new Date();

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,5 +1,5 @@
 import * as esaml2 from '../index';
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import test from 'ava';
 import { verifyTime } from '../src/validator';
 
@@ -234,7 +234,7 @@ test('getAssertionConsumerService with two bindings', t => {
       t.is(e.message, 'ERR_FAILED_TO_VERIFY_SIGNATURE');
     }
   });
-  
+
   test('verify a XML signature with metadata but with rolling certificate', t => {
 
     const responseSignedByCert1 = String(readFileSync('./test/misc/response_signed_cert1.xml'));
@@ -354,7 +354,7 @@ test('idp with multiple signing and encryption certificates', t => {
 })
 
 test('verify time with and without drift tolerance', t => {
-  
+
   const now = new Date();
   const timeBefore10Mins = new Date(new Date().setMinutes(now.getMinutes() - 10)).toISOString();
   const timeBefore5Mins = new Date(new Date().setMinutes(now.getMinutes() - 5)).toISOString();
@@ -365,7 +365,7 @@ test('verify time with and without drift tolerance', t => {
   t.true(verifyTime(timeBefore5Mins, timeAfter5Mins));
   t.true(verifyTime(timeBefore5Mins, undefined));
   t.true(verifyTime(undefined, timeAfter5Mins));
-  
+
   t.false(verifyTime(undefined, timeBefore5Mins));
   t.false(verifyTime(timeAfter5Mins, undefined));
   t.false(verifyTime(timeBefore10Mins, timeBefore5Mins));
@@ -383,7 +383,7 @@ test('verify time with and without drift tolerance', t => {
   t.true(verifyTime(timeAfter5Mins, undefined, drifts));
   t.true(verifyTime(timeBefore10Mins, timeBefore5Mins, drifts));
   t.true(verifyTime(timeAfter5Mins, timeAfter10Mins, drifts));
-  
+
   t.true(verifyTime(undefined, undefined, drifts));
 });
 


### PR DESCRIPTION
Brings the `signingCert` and `encryptCert` args on the entities up to parity with raw metadata when multiple KeyDescriptors are desired for each use.

@tngan 