### PR TITLE
Fixes #514 -- removing node when not using exclusive canonicalization fails validation

### DIFF
--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -444,8 +444,6 @@ const libSaml = () => {
 
         sig.loadSignature(signatureNode);
 
-        doc.removeChild(signatureNode);
-
         verified = verified && sig.checkSignature(doc.toString());
 
         // immediately throw error when any one of the signature is failed to get verified


### PR DESCRIPTION
Removing the signature node can fail validation if IdPs doesn't use exclusive canonization. While this is a recommendation in the SAML 2.0 RFC, it's not a requirement and therefore samlify failing here is unexpected behavior.