### PR TITLE
Add dom parser options for context customization

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,8 +11,8 @@ export { default as SamlLib } from './src/libsaml';
 import * as Constants from './src/urn';
 import * as Extractor from './src/extractor';
 
-// exposed methods for customising samlify
-import { setSchemaValidator } from './src/api';
+// exposed methods for customizing samlify
+import { setSchemaValidator, setDOMParserOptions } from './src/api';
 
 export {
   Constants,
@@ -23,5 +23,6 @@ export {
   ServiceProvider,
   ServiceProviderInstance,
   // set context
-  setSchemaValidator
+  setSchemaValidator,
+  setDOMParserOptions
 };

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import type { Options as DOMParserOptions } from '@xmldom/xmldom';
+import { DOMParser as dom, Options as DOMParserOptions } from '@xmldom/xmldom';
 
 // global module configuration
 interface Context extends ValidatorContext, DOMParserContext {}
@@ -8,12 +8,12 @@ interface ValidatorContext {
 }
 
 interface DOMParserContext {
-  domParserOpts: DOMParserOptions;
+  dom: dom;
 }
 
 const context: Context = {
   validate: undefined,
-  domParserOpts: {}
+  dom: new dom()
 };
 
 export function getContext() {
@@ -31,6 +31,6 @@ export function setSchemaValidator(params: ValidatorContext) {
 
 }
 
-export function setDOMParserOptions(params: DOMParserContext) {
-  context.domParserOpts = params.domParserOpts || {};
+export function setDOMParserOptions(options: DOMParserOptions = {}) {
+  context.dom = new dom(options);
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,12 +1,19 @@
+import type { Options as DOMParserOptions } from '@xmldom/xmldom';
+
 // global module configuration
-interface Context extends ValidatorContext {}
+interface Context extends ValidatorContext, DOMParserContext {}
 
 interface ValidatorContext {
   validate?: (xml: string) => Promise<any>;
 }
 
+interface DOMParserContext {
+  domParserOpts: DOMParserOptions;
+}
+
 const context: Context = {
-  validate: undefined
+  validate: undefined,
+  domParserOpts: {}
 };
 
 export function getContext() {
@@ -22,4 +29,8 @@ export function setSchemaValidator(params: ValidatorContext) {
   // assign the validate function to the context
   context.validate = params.validate;
 
+}
+
+export function setDOMParserOptions(params: DOMParserContext) {
+  context.domParserOpts = params.domParserOpts || {};
 }

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -1,6 +1,7 @@
 import { DOMParser } from '@xmldom/xmldom';
 import { select, SelectedValue } from 'xpath';
 import { uniq, last, zipObject, notEmpty } from './utility';
+import { getContext } from './api';
 import camelCase from 'camelcase';
 const dom = DOMParser;
 
@@ -198,8 +199,8 @@ export const logoutResponseFields: ExtractorFields = [
 ];
 
 export function extract(context: string, fields) {
-
-  const rootDoc = new dom().parseFromString(context);
+  const { domParserOpts } = getContext();
+  const rootDoc = new dom(domParserOpts).parseFromString(context);
 
   return fields.reduce((result: any, field) => {
     // get essential fields
@@ -218,7 +219,7 @@ export function extract(context: string, fields) {
     // if shortcut is used, then replace the doc
     // it's a design for overriding the doc used during runtime
     if (shortcut) {
-      targetDoc = new dom().parseFromString(shortcut);
+      targetDoc = new dom(domParserOpts).parseFromString(shortcut);
     }
 
     // special case: multiple path
@@ -273,7 +274,7 @@ export function extract(context: string, fields) {
       const fullChildXPath = `${childXPath}${childAttributeXPath}`;
       // [ 'test', 'test@example.com', [ 'users', 'examplerole1' ] ]
       const childAttributes = parentNodes.map(node => {
-        const nodeDoc = new dom().parseFromString(node.toString());
+        const nodeDoc = new dom(domParserOpts).parseFromString(node.toString());
         if (attributes.length === 0) {
           const childValues = select(fullChildXPath, nodeDoc).map((n: Node) => n.nodeValue);
           if (childValues.length === 1) {
@@ -334,7 +335,7 @@ export function extract(context: string, fields) {
       const baseNode = select(baseXPath, targetDoc).map(n => n.toString());
       const childXPath = `${buildAbsoluteXPath([last(localPath)])}${attributeXPath}`;
       const attributeValues = baseNode.map((node: string) => {
-        const nodeDoc = new dom().parseFromString(node);
+        const nodeDoc = new dom(domParserOpts).parseFromString(node);
         const values = select(childXPath, nodeDoc).reduce((r: any, n: Attr) => {
           r[camelCase(n.name, {locale: 'en-us'})] = n.value;
           return r;

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -1,9 +1,7 @@
-import { DOMParser } from '@xmldom/xmldom';
 import { select, SelectedValue } from 'xpath';
 import { uniq, last, zipObject, notEmpty } from './utility';
 import { getContext } from './api';
 import camelCase from 'camelcase';
-const dom = DOMParser;
 
 interface ExtractorField {
   key: string;
@@ -199,8 +197,8 @@ export const logoutResponseFields: ExtractorFields = [
 ];
 
 export function extract(context: string, fields) {
-  const { domParserOpts } = getContext();
-  const rootDoc = new dom(domParserOpts).parseFromString(context);
+  const { dom } = getContext();
+  const rootDoc = dom.parseFromString(context);
 
   return fields.reduce((result: any, field) => {
     // get essential fields
@@ -219,7 +217,7 @@ export function extract(context: string, fields) {
     // if shortcut is used, then replace the doc
     // it's a design for overriding the doc used during runtime
     if (shortcut) {
-      targetDoc = new dom(domParserOpts).parseFromString(shortcut);
+      targetDoc = dom.parseFromString(shortcut);
     }
 
     // special case: multiple path
@@ -274,7 +272,7 @@ export function extract(context: string, fields) {
       const fullChildXPath = `${childXPath}${childAttributeXPath}`;
       // [ 'test', 'test@example.com', [ 'users', 'examplerole1' ] ]
       const childAttributes = parentNodes.map(node => {
-        const nodeDoc = new dom(domParserOpts).parseFromString(node.toString());
+        const nodeDoc = dom.parseFromString(node.toString());
         if (attributes.length === 0) {
           const childValues = select(fullChildXPath, nodeDoc).map((n: Node) => n.nodeValue);
           if (childValues.length === 1) {
@@ -335,7 +333,7 @@ export function extract(context: string, fields) {
       const baseNode = select(baseXPath, targetDoc).map(n => n.toString());
       const childXPath = `${buildAbsoluteXPath([last(localPath)])}${attributeXPath}`;
       const attributeValues = baseNode.map((node: string) => {
-        const nodeDoc = new dom(domParserOpts).parseFromString(node);
+        const nodeDoc = dom.parseFromString(node);
         const values = select(childXPath, nodeDoc).reduce((r: any, n: Attr) => {
           r[camelCase(n.name, {locale: 'en-us'})] = n.value;
           return r;

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -4,7 +4,6 @@
 * @desc  A simple library including some common functions
 */
 
-import { DOMParser } from '@xmldom/xmldom';
 import utility, { flattenDeep, isString } from './utility';
 import { algorithms, wording, namespace } from './urn';
 import { select } from 'xpath';
@@ -20,7 +19,6 @@ const signatureAlgorithms = algorithms.signature;
 const digestAlgorithms = algorithms.digest;
 const certUse = wording.certUse;
 const urlParams = wording.urlParams;
-const dom = DOMParser;
 
 export interface SignatureConstructor {
   rawSamlMessage: string;
@@ -355,8 +353,8 @@ const libSaml = () => {
     * @return {boolean} verification result
     */
     verifySignature(xml: string, opts: SignatureVerifierOptions) {
-      const { domParserOpts } = getContext();
-      const doc = new dom(domParserOpts).parseFromString(xml);
+      const { dom } = getContext();
+      const doc = dom.parseFromString(xml);
       // In order to avoid the wrapping attack, we have changed to use absolute xpath instead of naively fetching the signature element
       // message signature (logout response / saml response)
       const messageSignatureXpath = "/*[contains(local-name(), 'Response') or contains(local-name(), 'Request')]/*[local-name(.)='Signature']";
@@ -604,8 +602,8 @@ const libSaml = () => {
 
         const sourceEntitySetting = sourceEntity.entitySetting;
         const targetEntityMetadata = targetEntity.entityMeta;
-        const { domParserOpts } = getContext();
-        const doc = new dom(domParserOpts).parseFromString(xml);
+        const { dom } = getContext();
+        const doc = dom.parseFromString(xml);
         const assertions = select("//*[local-name(.)='Assertion']", doc) as Node[];
         if (!Array.isArray(assertions) || assertions.length === 0) {
           throw new Error('ERR_NO_ASSERTION');
@@ -635,7 +633,7 @@ const libSaml = () => {
               return reject(new Error('ERR_UNDEFINED_ENCRYPTED_ASSERTION'));
             }
             const { encryptedAssertion: encAssertionPrefix } = sourceEntitySetting.tagPrefix;
-            const encryptAssertionDoc = new dom(domParserOpts).parseFromString(`<${encAssertionPrefix}:EncryptedAssertion xmlns:${encAssertionPrefix}="${namespace.names.assertion}">${res}</${encAssertionPrefix}:EncryptedAssertion>`);
+            const encryptAssertionDoc = dom.parseFromString(`<${encAssertionPrefix}:EncryptedAssertion xmlns:${encAssertionPrefix}="${namespace.names.assertion}">${res}</${encAssertionPrefix}:EncryptedAssertion>`);
             doc.documentElement.replaceChild(encryptAssertionDoc.documentElement, rawAssertionNode);
             return resolve(utility.base64Encode(doc.toString()));
           });
@@ -660,8 +658,8 @@ const libSaml = () => {
         }
         // Perform encryption depends on the setting of where the message is sent, default is false
         const hereSetting = here.entitySetting;
-        const { domParserOpts } = getContext();
-        const doc = new dom(domParserOpts).parseFromString(entireXML);
+        const { dom  } = getContext();
+        const doc = dom.parseFromString(entireXML);
         const encryptedAssertions = select("/*[contains(local-name(), 'Response')]/*[local-name(.)='EncryptedAssertion']", doc) as Node[];
         if (!Array.isArray(encryptedAssertions) || encryptedAssertions.length === 0) {
           throw new Error('ERR_UNDEFINED_ENCRYPTED_ASSERTION');
@@ -681,7 +679,7 @@ const libSaml = () => {
           if (!res) {
             return reject(new Error('ERR_UNDEFINED_ENCRYPTED_ASSERTION'));
           }
-          const rawAssertionDoc = new dom(domParserOpts).parseFromString(res);
+          const rawAssertionDoc = dom.parseFromString(res);
           doc.documentElement.replaceChild(rawAssertionDoc.documentElement, encAssertionNode);
           return resolve([doc.toString(), res]);
         });


### PR DESCRIPTION
Decided to have a go at #534, tried to do it by adding `@xmldom/xmldom` parser options to the context, and using it when creating parser instances

closes #534 