### PR TITLE
Adds `allowCreate` documentation

### DIFF
--- a/docs/sp-configuration.md
+++ b/docs/sp-configuration.md
@@ -63,6 +63,9 @@ const sp = new ServiceProvider({
 
 #### Optional Parameters
 
+- **allowCreate: Boolean**<br/>
+	Declare if identitiy provider is allowed, in the course of fulfilling the request, to create a new identifier to represent the principal, default to `false`
+
 - **loginRequestTemplate: {context: String, attributes: Attributes}**<br/>
   Customize the login request template, and user can reuse it in the callback function to do runtime interpolation. (See [more](/template)) 
 


### PR DESCRIPTION
- credit to https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf for language
- option was made configurable in https://github.com/tngan/samlify/pull/363
- noticed while looking into [reported issue](https://github.com/tngan/samlify/issues/538) that docs needed updating