### PR TITLE
fix: escapeTag correctly works with booleans

### DIFF
--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -242,7 +242,8 @@ const libSaml = () => {
   function escapeTag(text: string): (...args: string[]) => string {
     return (match: string, quote?: string) => {
       // not having a quote means this interpolation isn't for an attribute, and so does not need escaping
-      return quote ? `${quote}${xmlEscape(text || '')}` : text;
+      const value = text === undefined || text === null ? "" : `${text}`;
+      return quote ? `${quote}${xmlEscape(value)}` : text;
     }
   }
 


### PR DESCRIPTION
In relation to https://github.com/tngan/samlify/issues/538, the issue boils down to the code in `escapeTag`, where we call

```
xmlEscape(text || "")
```

This fails for "falsey" values, in our case for `AllowCreate` being `false`. Even passing `true`, we end up with an error as the `xml-escape` [lib](https://github.com/miketheprogrammer/xml-escape/blob/master/index.js) used actually expects a string.

This PR tests for `undefined` and `null`, where it'll pass an empty string. For all other values, it will convert to a string. As a result, our `AllowCreate` gets correctly set

```
...
<samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" AllowCreate="false"/></samlp:AuthnRequest>
```