### PR TITLE
Fix XML Signature Removal Bug

### DIFF
--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -263,11 +263,13 @@ const libSaml = () => {
     * @param  {array} tagValues    tag values
     * @return {string}
     */
-    replaceTagsByValue(rawXML: string, tagValues: any): string {
+    replaceTagsByValue(rawXML: string, tagValues: Record<string, unknown>): string {
       Object.keys(tagValues).forEach(t => {
+        let tagValue = tagValues[t];
+        tagValue = tagValue == null ? tagValue : tagValue.toString();
         rawXML = rawXML.replace(
           new RegExp(`("?)\\{${t}\\}`, 'g'),
-          escapeTag(tagValues[t])
+          escapeTag(tagValue as string)
         );
       });
       return rawXML;
@@ -453,7 +455,7 @@ const libSaml = () => {
 
         sig.loadSignature(signatureNode);
 
-        doc.removeChild(signatureNode);
+        signatureNode.parentNode.removeChild(signatureNode);
 
         verified = verified && sig.checkSignature(doc.toString());
 


### PR DESCRIPTION
Currently we are removing the XML signature from a Login Response prior to validating the signature in the library. The usage of `xmldom`'s `removeChild` is incorrect. `removeChild` must be called on the direct parent of the node to be removed, in the code right now it is being called on the root document which is not always the parent of the signature doc (for example, an XML response with a Prolog). This throws an error in newer versions of `xmldom` preventing upgrade of this module and can produce unexpected invalid XML for some XMLs (sample reproduced in tests). See https://github.com/xmldom/xmldom/issues/135 for more details on this issue and why this now throws an error on newer version of XML.

This PR fixes that issue by ensuring it is always calling `removeChild` on the direct parent of the signature node. This PR also fixes an issue breaking existing tests with template replacement where `false` values provided to a template would produce an empty string instead of the value `false`.


---

As mentioned in some older issues and other PRs, the removal of the XML signature is not necessary for `xml-crypto` for the library to validate. Another solution would be to remove this entirely (This currently open PR: https://github.com/tngan/samlify/pull/515 and Issue: https://github.com/tngan/samlify/issues/514 are about this). I do see in the original PR mentioned removing this helps with debugging but is also necessary when there are multiple signatures https://github.com/tngan/samlify/commit/d382bbc7c6b8ea889839ae1f178730c25b09eb42#r31013727

> here is a bug fix in v2.4.0. The order the two signature proceeds is sign assertion -> sign entire message. Therefore we need to verify the message signature first, then we verify the assertion signature. In this case, no matter it removes the signature node or not, it doesn’t affect the outcome. Removal of signature node here makes more sense for debugging, since the document is reverted to the state when it is signed. For example, when you debug and verify the message signature, you will see there is an assertion signature, that's the same state when you sign the message signature.
> 
> However, we accidentally verify assertion signature first in the rc version (and before), once the assertion signature is verified, then I remove the assertion signature, it will affect the next verification for message signature, because the assertion signature exists when you sign entire message signature, that's why it works after you comment out the line but it's not correct.
> 
> For more detail about the fix, please take a look in https://github.com/tngan/samlify/issues/219

I didn't come across any test cases for that specific issue so I was not able to replicate the bug that not removing the signature introduces so think to minimize change updating this to correctly remove the signature element is the safer option.