### PR TITLE
Fix `escapeTag` for non-string replacement values.

### DIFF
--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -204,14 +204,10 @@ const libSaml = () => {
   * @private
   * @desc Get the digest algorithms by signature algorithms
   * @param {string} sigAlg    signature algorithm
-  * @return {string/null} digest algorithm
+  * @return {string/undefined} digest algorithm
   */
-  function getDigestMethod(sigAlg: string): string | null {
-    const digestAlg = digestAlgorithms[sigAlg];
-    if (!(digestAlg === undefined)) {
-      return digestAlg;
-    }
-    return null; // default value
+  function getDigestMethod(sigAlg: string): string | undefined {
+    return digestAlgorithms[sigAlg];
   }
   /**
   * @public
@@ -239,10 +235,12 @@ const libSaml = () => {
     return prefix + camelContent.charAt(0).toUpperCase() + camelContent.slice(1);
   }
 
-  function escapeTag(text: string): (...args: string[]) => string {
-    return (match: string, quote?: string) => {
+  function escapeTag(replacement: unknown): (...args: string[]) => string {
+    return (_match: string, quote?: string) => {
+      const text: string = (replacement === null || replacement === undefined) ? '' : String(replacement);
+
       // not having a quote means this interpolation isn't for an attribute, and so does not need escaping
-      return quote ? `${quote}${xmlEscape(text || '')}` : text;
+      return quote ? `${quote}${xmlEscape(text)}` : text;
     }
   }
 
@@ -263,7 +261,7 @@ const libSaml = () => {
     * @param  {array} tagValues    tag values
     * @return {string}
     */
-    replaceTagsByValue(rawXML: string, tagValues: any): string {
+    replaceTagsByValue(rawXML: string, tagValues: Record<string, unknown>): string {
       Object.keys(tagValues).forEach(t => {
         rawXML = rawXML.replace(
           new RegExp(`("?)\\{${t}\\}`, 'g'),

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -1077,7 +1077,7 @@ test('idp sends a post logout request with signature and sp parses it', async t 
 
 // simulate init-slo
 test('sp sends a post logout response without signature and parse', async t => {
-  const { context: SAMLResponse } = sp.createLogoutResponse(idp, null, 'post', '', createTemplateCallback(idp, sp, binding.post, {})) as PostBindingContext;
+  const { context: SAMLResponse } = sp.createLogoutResponse(idp, sampleRequestInfo, 'post', '', createTemplateCallback(idp, sp, binding.post, {})) as PostBindingContext;
   const { extract } = await idp.parseLogoutResponse(sp, 'post', { body: { SAMLResponse }});
   t.is(extract.signature, null);
   t.is(extract.issuer, 'https://sp.example.org/metadata');

--- a/test/issues.ts
+++ b/test/issues.ts
@@ -1,10 +1,9 @@
-import esaml2 = require('../index');
-import { readFileSync, writeFileSync } from 'fs';
+import * as esaml2 from '../index';
+import { readFileSync } from 'fs';
 import test from 'ava';
 import * as fs from 'fs';
 import * as url from 'url';
 import { DOMParser as dom } from '@xmldom/xmldom';
-import { xpath as select } from 'xml-crypto';
 import { extract } from '../src/extractor';
 
 const {
@@ -153,15 +152,14 @@ test('#31 query param for sso/slo returns error', t => {
   test('#91 idp gets single sign on service from the metadata', t => {
     t.is(idp.entityMeta.getSingleSignOnService('post'), 'idp.example.com/sso');
   });
-  
+
   test('#98 undefined AssertionConsumerServiceURL with redirect request', t => {
-    const { id, context } = sp98.createLoginRequest(idp, 'redirect');
+    const { context } = sp98.createLoginRequest(idp, 'redirect');
     const originalURL = url.parse(context, true);
     const request = originalURL.query.SAMLRequest as string;
     const rawRequest = utility.inflateString(decodeURIComponent(request));
     const xml = new dom().parseFromString(rawRequest);
-    const authnRequest = select(xml, "/*[local-name(.)='AuthnRequest']")[0];
-    const index = Object.keys(authnRequest.attributes).find((i: string) => authnRequest.attributes[i].nodeName === 'AssertionConsumerServiceURL') as any;
-    t.is(authnRequest.attributes[index].nodeValue, 'https://example.org/response');
+    const acsUrl = xml.documentElement.attributes.getNamedItem('AssertionConsumerServiceURL')?.value;
+    t.is(acsUrl, 'https://example.org/response');
   });
 })();


### PR DESCRIPTION
Fixes #538 for bug introduced in #523 (v2.8.11).

The values passed to `replaceTagsByValue` are not always strings, notably `allowCreate` is a boolean. These values need to be cast to their string equivalents before being passed into `xmlEscape`.

It's worth calling out the test suite has not been passing since the bug was introduced, it caused four tests to start failing. I did not add any new tests, however, the test suite passes again with these changes. 

Other changes, return type of `getDigestMethod`  and test updates, were related to the recent update of `xml-crypto`.

cc @tngan  @Munawwar @D-32