### PR TITLE
Handle `encrypt-then-sign` with encrypted Assertions

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -211,7 +211,7 @@ async function postFlow(options): Promise<FlowResult> {
     checkSignature &&
     from.entitySetting.messageSigningOrder === MessageSignatureOrder.ETS
   ) {
-    const [verified, verifiedAssertionNode] = libsaml.verifySignature(samlContent, verificationOptions);
+    const [verified, verifiedAssertionNode] = libsaml.verifySignature(samlContent, verificationOptions, decryptRequired);
     if (!verified) {
       return Promise.reject('ERR_FAIL_TO_VERIFY_ETS_SIGNATURE');
     }

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -366,7 +366,7 @@ const libSaml = () => {
      *   - The first element is `true` if the signature is valid, `false` otherwise.
      *   - The second element is the cryptographically authenticated assertion node as a string, or `null` if not found.
      */
-    verifySignature(xml: string, opts: SignatureVerifierOptions, isAssertionEncrypted: boolean) {
+    verifySignature(xml: string, opts: SignatureVerifierOptions, isAssertionEncrypted: boolean = false) {
       const { dom } = getContext();
       const doc = dom.parseFromString(xml);
 
@@ -486,6 +486,7 @@ const libSaml = () => {
           if (assertions.length === 1) {
             return [true, assertions[0].toString()];
           } else if (isAssertionEncrypted) {
+            // if the assertions are encrypted there will be no 'Assertion' nodes
             return [true, null];
           }
         } else if (rootNode.localName === 'Assertion') {

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -366,7 +366,7 @@ const libSaml = () => {
      *   - The first element is `true` if the signature is valid, `false` otherwise.
      *   - The second element is the cryptographically authenticated assertion node as a string, or `null` if not found.
      */
-    verifySignature(xml: string, opts: SignatureVerifierOptions) {
+    verifySignature(xml: string, opts: SignatureVerifierOptions, isAssertionEncrypted: boolean) {
       const { dom } = getContext();
       const doc = dom.parseFromString(xml);
 
@@ -485,6 +485,8 @@ const libSaml = () => {
           // now we can process the assertion as an assertion
           if (assertions.length === 1) {
             return [true, assertions[0].toString()];
+          } else if (isAssertionEncrypted) {
+            return [true, null];
           }
         } else if (rootNode.localName === 'Assertion') {
           return [true, rootNode.toString()];


### PR DESCRIPTION
## Problem

We had an issue where a Response with a signature and `EncryptedAssertion`'s was failing in the change to the `verifySignature` method.

The Response did not contain any normal `Assertion` nodes and thus would fail with `ERR_ZERO_SIGNATURE` from these lines: 

https://github.com/tngan/samlify/blob/master/src/libsaml.ts#L496-L497

however the `assertionNode` in the response from `verifySignature` is only used if the `decryptRequired` flag is not set when it is using `encrypt-then-sign` so looks like it should be ok to ignore node in this part of the response from: 

https://github.com/tngan/samlify/blob/master/src/flow.ts#L223-L227

## Changes

- Returns `assertionNode: null` from `verifySignature` when `entitySetting.isAssertionEncrypted` is set.