### PR TITLE
Add login relay state 

### DIFF
--- a/src/binding-redirect.ts
+++ b/src/binding-redirect.ts
@@ -83,7 +83,7 @@ function buildRedirectURL(opts: BuildRedirectConfig) {
 * @param  {function} customTagReplacement      used when developers have their own login response template
 * @return {string} redirect URL
 */
-function loginRequestRedirectURL(entity: { idp: Idp, sp: Sp }, customTagReplacement?: (template: string) => BindingContext): BindingContext {
+function loginRequestRedirectURL(entity: { idp: Idp, sp: Sp, relayState?: string }, customTagReplacement?: (template: string) => BindingContext): BindingContext {
 
   const metadata: any = { idp: entity.idp.entityMeta, sp: entity.sp.entityMeta };
   const spSetting: any = entity.sp.entitySetting;
@@ -123,7 +123,7 @@ function loginRequestRedirectURL(entity: { idp: Idp, sp: Sp }, customTagReplacem
         isSigned: metadata.sp.isAuthnRequestSigned(),
         entitySetting: spSetting,
         baseUrl: base,
-        relayState: spSetting.relayState,
+        relayState: entity.relayState !== undefined ? entity.relayState : spSetting.relayState,
       }),
     };
   }
@@ -232,7 +232,8 @@ function loginResponseRedirectURL(requestInfo: any, entity: any, user: any = {},
 * @desc Redirect URL for logout request
 * @param  {object} user                        current logged user (e.g. req.user)
 * @param  {object} entity                      object includes both idp and sp
-* @param  {function} customTagReplacement     used when developers have their own login response template
+* @param  {string} [relayState]                object includes both idp and sp
+* @param  {function} [customTagReplacement]    used when developers have their own login response template
 * @return {string} redirect URL
 */
 function logoutRequestRedirectURL(user, entity, relayState?: string, customTagReplacement?: (template: string, tags: object) => BindingContext): BindingContext {

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -52,12 +52,14 @@ export class ServiceProvider extends Entity {
   * @desc  Generates the login request for developers to design their own method
   * @param  {IdentityProvider} idp               object of identity provider
   * @param  {string}   binding                   protocol binding
-  * @param  {function} customTagReplacement     used when developers have their own login response template
+  * @param  {function} [customTagReplacement]    used when developers have their own login response template
+  * @param  {string}   [relayState]              relay state override. pass empty string to remove sp's relay state.
   */
   public createLoginRequest(
     idp: IdentityProvider,
     binding = 'redirect',
     customTagReplacement?: (template: string) => BindingContext,
+    relayState?: string,
   ): BindingContext | PostBindingContext| SimpleSignBindingContext  {
     const nsBinding = namespace.binding;
     const protocol = nsBinding[binding];
@@ -68,7 +70,7 @@ export class ServiceProvider extends Entity {
     let context: any = null;
     switch (protocol) {
       case nsBinding.redirect:
-        return redirectBinding.loginRequestRedirectURL({ idp, sp: this }, customTagReplacement);
+        return redirectBinding.loginRequestRedirectURL({ idp, sp: this, relayState }, customTagReplacement);
 
       case nsBinding.post:
         context = postBinding.base64LoginRequest("/*[local-name(.)='AuthnRequest']", { idp, sp: this }, customTagReplacement);
@@ -86,7 +88,7 @@ export class ServiceProvider extends Entity {
 
     return {
       ...context,
-      relayState: this.entitySetting.relayState,
+      relayState: relayState !== undefined ? relayState : this.entitySetting.relayState,
       entityEndpoint: idp.entityMeta.getSingleSignOnService(binding) as string,
       type: 'SAMLRequest',
     };

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -181,6 +181,18 @@ test('create login request with redirect binding using default template and pars
   expect(extract.nameIDPolicy.allowCreate).toBe('false');
 });
 
+test('create login request with redirect binding relayState override and removal', () => {
+  const noRelayStateReq = url.parse(serviceProvider(defaultSpConfig).createLoginRequest(idp, 'redirect').context, true);
+  const _sp = serviceProvider({ ...defaultSpConfig, relayState: 'default-relay-state' });
+  const defaultReq = url.parse(_sp.createLoginRequest(idp, 'redirect').context, true);
+  const overrideReq = url.parse(_sp.createLoginRequest(idp, 'redirect', undefined, 'override-relay-state').context, true);
+  const removedReq = url.parse(_sp.createLoginRequest(idp, 'redirect', undefined, '').context, true);
+  expect(noRelayStateReq.query.RelayState).toBeUndefined();
+  expect(defaultReq.query.RelayState).toBe('default-relay-state');
+  expect(overrideReq.query.RelayState).toBe('override-relay-state');
+  expect(removedReq.query.RelayState).toBeUndefined();
+});
+
 test('create login request with post simpleSign binding using default template and parse it', async () => {
   const { relayState, id, context: SAMLRequest, type, sigAlg, signature } = sp.createLoginRequest(idp, 'simpleSign') as SimpleSignBindingContext;
   expect(typeof id).toBe('string');


### PR DESCRIPTION
Hi. First off, thanks for this project. It made my life to implement SAML logins easier.

Login relay state is useful feature to pass some application states as opaque ids. I built this feature in 2023 and been using this patch in production for a long time. I rebased the change now though and added a unit test.

I am ware there is another PR now that attempts similar change: https://github.com/tngan/samlify/pull/583. But I am not sure why that PR has lot more changes than mine. I kept my changes minimal.