### PR TITLE
fix: reject promises with Error instances, not raw strings (#581)

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -95,7 +95,7 @@ async function redirectFlow(options: FlowOptions): Promise<FlowResult> {
   const content = (query as Record<string, string | undefined>)[direction];
 
   if (content === undefined) {
-    return Promise.reject('ERR_REDIRECT_FLOW_BAD_ARGS');
+    return Promise.reject(new Error('ERR_REDIRECT_FLOW_BAD_ARGS'));
   }
 
   const xmlString = inflateString(decodeURIComponent(content));
@@ -103,7 +103,7 @@ async function redirectFlow(options: FlowOptions): Promise<FlowResult> {
   try {
     await libsaml.isValidXml(xmlString);
   } catch {
-    return Promise.reject('ERR_INVALID_XML');
+    return Promise.reject(new Error('ERR_INVALID_XML'));
   }
 
   await checkStatus(xmlString, parserType as string);
@@ -132,7 +132,7 @@ async function redirectFlow(options: FlowOptions): Promise<FlowResult> {
 
   if (checkSignature) {
     if (!signature || !sigAlg) {
-      return Promise.reject('ERR_MISSING_SIG_ALG');
+      return Promise.reject(new Error('ERR_MISSING_SIG_ALG'));
     }
 
     const base64Signature = Buffer.from(decodeURIComponent(signature), 'base64');
@@ -146,7 +146,7 @@ async function redirectFlow(options: FlowOptions): Promise<FlowResult> {
     );
 
     if (!verified) {
-      return Promise.reject('ERR_FAILED_MESSAGE_SIGNATURE_VERIFICATION');
+      return Promise.reject(new Error('ERR_FAILED_MESSAGE_SIGNATURE_VERIFICATION'));
     }
 
     parseResult.sigAlg = decodeSigAlg;
@@ -160,7 +160,7 @@ async function redirectFlow(options: FlowOptions): Promise<FlowResult> {
     && extractedProperties
     && extractedProperties.issuer !== issuer
   ) {
-    return Promise.reject('ERR_UNMATCH_ISSUER');
+    return Promise.reject(new Error('ERR_UNMATCH_ISSUER'));
   }
 
   // Session expiration — only enforced when SessionNotOnOrAfter is present.
@@ -173,7 +173,7 @@ async function redirectFlow(options: FlowOptions): Promise<FlowResult> {
       self.entitySetting.clockDrifts,
     )
   ) {
-    return Promise.reject('ERR_EXPIRED_SESSION');
+    return Promise.reject(new Error('ERR_EXPIRED_SESSION'));
   }
 
   // Assertion validity window. SAML core 2.4.1.2.
@@ -186,7 +186,7 @@ async function redirectFlow(options: FlowOptions): Promise<FlowResult> {
       self.entitySetting.clockDrifts,
     )
   ) {
-    return Promise.reject('ERR_SUBJECT_UNCONFIRMED');
+    return Promise.reject(new Error('ERR_SUBJECT_UNCONFIRMED'));
   }
 
   return Promise.resolve(parseResult);
@@ -246,12 +246,12 @@ async function postFlow(options: FlowOptions): Promise<FlowResult> {
       if (decryptedDocVerified) {
         extractorFields = getDefaultExtractorFields(parserType, verifiedDecryptedAssertion);
       } else {
-        return Promise.reject('FAILED_TO_VERIFY_SIGNATURE');
+        return Promise.reject(new Error('FAILED_TO_VERIFY_SIGNATURE'));
       }
     } else if (verified) {
       extractorFields = getDefaultExtractorFields(parserType, verifiedAssertionNode);
     } else {
-      return Promise.reject('FAILED_TO_VERIFY_SIGNATURE');
+      return Promise.reject(new Error('FAILED_TO_VERIFY_SIGNATURE'));
     }
   }
 
@@ -269,7 +269,7 @@ async function postFlow(options: FlowOptions): Promise<FlowResult> {
     && extractedProperties
     && extractedProperties.issuer !== issuer
   ) {
-    return Promise.reject('ERR_UNMATCH_ISSUER');
+    return Promise.reject(new Error('ERR_UNMATCH_ISSUER'));
   }
 
   if (
@@ -281,7 +281,7 @@ async function postFlow(options: FlowOptions): Promise<FlowResult> {
       self.entitySetting.clockDrifts,
     )
   ) {
-    return Promise.reject('ERR_EXPIRED_SESSION');
+    return Promise.reject(new Error('ERR_EXPIRED_SESSION'));
   }
 
   if (
@@ -293,7 +293,7 @@ async function postFlow(options: FlowOptions): Promise<FlowResult> {
       self.entitySetting.clockDrifts,
     )
   ) {
-    return Promise.reject('ERR_SUBJECT_UNCONFIRMED');
+    return Promise.reject(new Error('ERR_SUBJECT_UNCONFIRMED'));
   }
 
   return Promise.resolve(parseResult);
@@ -316,7 +316,7 @@ async function postSimpleSignFlow(options: FlowOptions): Promise<FlowResult> {
   const signature: string = (body as Record<string, string>)['Signature'];
 
   if (encodedRequest === undefined) {
-    return Promise.reject('ERR_SIMPLESIGN_FLOW_BAD_ARGS');
+    return Promise.reject(new Error('ERR_SIMPLESIGN_FLOW_BAD_ARGS'));
   }
 
   const xmlString = String(base64Decode(encodedRequest));
@@ -324,7 +324,7 @@ async function postSimpleSignFlow(options: FlowOptions): Promise<FlowResult> {
   try {
     await libsaml.isValidXml(xmlString);
   } catch {
-    return Promise.reject('ERR_INVALID_XML');
+    return Promise.reject(new Error('ERR_INVALID_XML'));
   }
 
   await checkStatus(xmlString, parserType as string);
@@ -353,7 +353,7 @@ async function postSimpleSignFlow(options: FlowOptions): Promise<FlowResult> {
 
   if (checkSignature) {
     if (!signature || !sigAlg) {
-      return Promise.reject('ERR_MISSING_SIG_ALG');
+      return Promise.reject(new Error('ERR_MISSING_SIG_ALG'));
     }
 
     const base64Signature = Buffer.from(signature, 'base64');
@@ -366,7 +366,7 @@ async function postSimpleSignFlow(options: FlowOptions): Promise<FlowResult> {
     );
 
     if (!verified) {
-      return Promise.reject('ERR_FAILED_MESSAGE_SIGNATURE_VERIFICATION');
+      return Promise.reject(new Error('ERR_FAILED_MESSAGE_SIGNATURE_VERIFICATION'));
     }
 
     parseResult.sigAlg = sigAlg;
@@ -380,7 +380,7 @@ async function postSimpleSignFlow(options: FlowOptions): Promise<FlowResult> {
     && extractedProperties
     && extractedProperties.issuer !== issuer
   ) {
-    return Promise.reject('ERR_UNMATCH_ISSUER');
+    return Promise.reject(new Error('ERR_UNMATCH_ISSUER'));
   }
 
   if (
@@ -392,7 +392,7 @@ async function postSimpleSignFlow(options: FlowOptions): Promise<FlowResult> {
       self.entitySetting.clockDrifts,
     )
   ) {
-    return Promise.reject('ERR_EXPIRED_SESSION');
+    return Promise.reject(new Error('ERR_EXPIRED_SESSION'));
   }
 
   if (
@@ -404,7 +404,7 @@ async function postSimpleSignFlow(options: FlowOptions): Promise<FlowResult> {
       self.entitySetting.clockDrifts,
     )
   ) {
-    return Promise.reject('ERR_SUBJECT_UNCONFIRMED');
+    return Promise.reject(new Error('ERR_SUBJECT_UNCONFIRMED'));
   }
 
   return Promise.resolve(parseResult);
@@ -468,5 +468,5 @@ export function flow(options: FlowOptions): Promise<FlowResult> {
     return postSimpleSignFlow(options);
   }
 
-  return Promise.reject('ERR_UNEXPECTED_FLOW');
+  return Promise.reject(new Error('ERR_UNEXPECTED_FLOW'));
 }

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -755,9 +755,9 @@ const libSaml = () => {
       const { validate } = getContext();
 
       if (!validate) {
-        return Promise.reject(
+        return Promise.reject(new Error(
           'Your application is potentially vulnerable because no validation function found. Please read the documentation on how to setup the validator. (https://github.com/tngan/samlify#installation)',
-        );
+        ));
       }
 
       return await validate(input);

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -1269,7 +1269,7 @@ test.sequential('should throw ERR_SUBJECT_UNCONFIRMED for the expired SAML respo
     // test failed, it shouldn't happen
     expect(true).toBe(false);
   } catch (e: any) {
-    expect(e).toBe('ERR_SUBJECT_UNCONFIRMED');
+    expect(e.message).toBe('ERR_SUBJECT_UNCONFIRMED');
   } finally {
     tk.reset();
   }
@@ -1292,7 +1292,7 @@ test.sequential('should throw ERR_SUBJECT_UNCONFIRMED for the expired SAML respo
     // test failed, it shouldn't happen
     expect(true).toBe(false);
   } catch (e: any) {
-    expect(e).toBe('ERR_SUBJECT_UNCONFIRMED');
+    expect(e.message).toBe('ERR_SUBJECT_UNCONFIRMED');
   } finally {
     tk.reset();
   }
@@ -1314,7 +1314,7 @@ test.sequential('should throw ERR_SUBJECT_UNCONFIRMED for the expired SAML respo
     // test failed, it shouldn't happen
     expect(true).toBe(false);
   } catch (e: any) {
-    expect(e).toBe('ERR_SUBJECT_UNCONFIRMED');
+    expect(e.message).toBe('ERR_SUBJECT_UNCONFIRMED');
   } finally {
     tk.reset();
   }

--- a/test/units.ts
+++ b/test/units.ts
@@ -422,7 +422,21 @@ describe('flow — checkStatus and dispatch errors', () => {
       request: { query: {}, body: {} },
       self: {} as any,
       from: {} as any,
-    })).rejects.toBe('ERR_UNEXPECTED_FLOW');
+    })).rejects.toThrow('ERR_UNEXPECTED_FLOW');
+  });
+
+  test('flow rejects with an Error instance, not a raw string (#581)', async () => {
+    const { flow } = await import('../src/flow');
+    const err = await flow({
+      binding: 'artifact',
+      parserType: 'SAMLRequest',
+      type: 'login',
+      request: { query: {}, body: {} },
+      self: {} as any,
+      from: {} as any,
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe('ERR_UNEXPECTED_FLOW');
   });
 });
 
@@ -632,7 +646,7 @@ describe('libsaml — encrypt/decrypt error paths', () => {
     const before = getContext().validate;
     getContext().validate = undefined;
     try {
-      await expect(libsaml.isValidXml('<x/>')).rejects.toContain('no validation function found');
+      await expect(libsaml.isValidXml('<x/>')).rejects.toThrow('no validation function found');
     } finally {
       getContext().validate = before;
     }


### PR DESCRIPTION
## Summary

Closes #581.

`flow.ts` and `libsaml.isValidXml` rejected promises with bare strings (e.g. `Promise.reject('ERR_INVALID_XML')`). As @-the-original-reporter pointed out, this is a poor practice — rejections lose their stack trace, force consumers into brittle string equality checks, and break tooling/lint rules that expect rejection values to be \`Error\` instances.

This PR converts all **21 string-rejection sites** to \`Promise.reject(new Error(...))\`:
- 20 in \`src/flow.ts\` (every redirect/post/simpleSign error path plus the final \`ERR_UNEXPECTED_FLOW\`)
- 1 in \`src/libsaml.ts\` (\`isValidXml\` when no validator has been registered)

Error messages are unchanged.

## ⚠️ BREAKING CHANGE

Consumers that catch flow rejections by raw string equality:

\`\`\`js
.catch(e => {
  if (e === 'ERR_INVALID_XML') { ... }
});
\`\`\`

must switch to:

\`\`\`js
.catch(e => {
  if (e.message === 'ERR_INVALID_XML') { ... }
});
\`\`\`

This warrants a minor version bump (and a CHANGELOG note, if/when one exists).

## Test plan

- [x] Update three test/flow.ts assertions that compared \`e\` directly against a string → switch to \`e.message\`.
- [x] Update two test/units.ts assertions (\`rejects.toBe\` and \`rejects.toContain\`) → \`rejects.toThrow\`.
- [x] Add a regression test that explicitly asserts the rejection value is an \`Error\` instance with the expected \`.message\` (covers the contract the issue is asking for).
- [x] Full suite passes: 222 tests, 1 skipped.
- [x] Coverage thresholds (≥90% on all four metrics) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)