### PR TITLE
docs: clarify that wantMessageSigned and signatureConfig are SP options (#516)

### DIFF
--- a/docs/signed-saml-response.md
+++ b/docs/signed-saml-response.md
@@ -104,10 +104,14 @@ const idp = IdentityProvider({
 
 ### Signed message, unsigned assertion (with or without encryption)
 
-Starting from v2, two additional IdP options extend the signing scheme: `wantMessageSigned` and `signatureConfig`. `signatureConfig` accepts the same options as [xml-crypto](https://github.com/yaronn/xml-crypto#examples).
+Starting from v2, the **service provider** can opt into a signed
+top-level `<Response>` via `wantMessageSigned` together with
+`signatureConfig`. `signatureConfig` accepts the same options as
+[xml-crypto](https://github.com/yaronn/xml-crypto#examples). The IdP
+honours these SP-side preferences when it builds the response.
 
 ```javascript
-const idp = IdentityProvider({
+const sp = ServiceProvider({
   // ...
   wantMessageSigned: true,
   signatureConfig: {
@@ -117,6 +121,12 @@ const idp = IdentityProvider({
       action: 'after'
     }
   }
+});
+
+const idp = IdentityProvider({
+  // ...
+  // No additional flags required: the IdP signs the message because
+  // the SP requested it.
 });
 ```
 


### PR DESCRIPTION
## Summary

Closes #516.

\`docs/signed-saml-response.md\` previously described \`wantMessageSigned\` and \`signatureConfig\` as IdP options and showed an example assigning both to the \`IdentityProvider\` constructor. That's inaccurate:

- Per \`src/types.ts\`, both fields live on \`ServiceProviderSettings\` (\`wantMessageSigned\` at line 216, \`signatureConfig\` at line 227) and on \`MetadataSpOptions\` (line 193). They are absent from \`IdentityProviderSettings\`.
- At runtime, the IdP's response-build path (\`src/binding-post.ts:195,217,229\`) reads \`spSetting.wantMessageSigned\` and \`spSetting.signatureConfig\` to decide whether to sign the top-level \`<Response>\` and where to place the \`<ds:Signature>\` element.

The fix moves the flags to the \`ServiceProvider\` where they belong and notes that the IdP doesn't need any extra flags — it honours the SP-side preference.

## Test plan

- [x] Cross-checked against the actual fields on \`ServiceProviderSettings\` and \`MetadataSpOptions\`.
- [x] Cross-checked against the runtime read sites in \`binding-post.ts\` (response message-signing block).
- [x] \`docs/okta.md:90\` already places \`wantMessageSigned\` on the SP — consistent with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)