### PR TITLE
RFC-0001: introduce .skills/ and mandatory SAML 2.0 spec citation workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Summary
+
+<!--
+A short paragraph: what changes, why, and what it closes / addresses.
+Link the issue if any: `Closes #N` / `Refs #N`.
+-->
+
+## Spec reference
+
+<!--
+REQUIRED for any PR touching src/.
+
+Cite the OASIS SAML 2.0 / W3C section this change implements, fixes,
+or extends. Use the form `<short-name> §<section>`. See
+`.skills/saml-spec-references.md` for the canonical short names and a
+module → spec map.
+
+Example:
+- `saml-bindings §3.4.4.1` — octet string construction for HTTP-Redirect.
+- `xmldsig-core §4.5` — `<KeyInfo>` element.
+
+If the change is genuinely spec-orthogonal (refactor, tooling, deps)
+write `N/A` and explain in one line.
+-->
+
+- 
+
+## Test plan
+
+<!--
+Bulleted checklist. For behaviour rules cited above, name the test
+that pins the rule.
+-->
+
+- [ ] 
+- [ ] 
+
+---
+
+By submitting this PR I confirm I have read [`.skills/spec-citation-workflow.md`](../.skills/spec-citation-workflow.md).

--- a/.skills/README.md
+++ b/.skills/README.md
@@ -1,0 +1,29 @@
+# `.skills/` — samlify development playbooks
+
+Skills are short, focused playbooks that capture conventions and workflows
+specific to maintaining samlify. They are intended to be readable by both
+human contributors and AI assistants (e.g. Claude Code, GitHub Copilot
+Workspace) so that the project's standards are applied consistently across
+PRs.
+
+## Index
+
+| Skill | When to invoke |
+| --- | --- |
+| [`spec-citation-workflow.md`](./spec-citation-workflow.md) | Every PR that touches `src/` (feature, bug fix, refactor) — cite the SAML 2.0 / W3C section the change implements or fixes. |
+| [`saml-spec-references.md`](./saml-spec-references.md) | Reference: canonical URLs for all OASIS SAML 2.0 documents, W3C XML-DSig / XML-Enc / canonicalization, plus a module → spec map for samlify itself. |
+| [`RFC-0001-spec-citation.md`](./RFC-0001-spec-citation.md) | The proposal that introduced these skills. |
+
+## How to add a skill
+
+1. Create a new file under `.skills/<short-kebab-name>.md`.
+2. Use the structure: **Purpose**, **When to apply**, **Procedure**, **Checklist**.
+3. Add a row to the index above.
+4. Open a PR with the `skill:` prefix in the title so reviewers can spot it.
+
+## Spec sources (offline)
+
+The `specs/` subdirectory is a *local-only* cache for PDF copies of the
+normative documents. Its contents are gitignored — see `specs/.gitignore`.
+Use the canonical URLs in `saml-spec-references.md` to download a copy when
+you need offline access.

--- a/.skills/RFC-0001-spec-citation.md
+++ b/.skills/RFC-0001-spec-citation.md
@@ -1,0 +1,107 @@
+# RFC-0001: Mandatory SAML 2.0 spec citation for code-touching PRs
+
+- **Status:** Draft
+- **Author:** *(maintainer to fill in)*
+- **Created:** 2026-04-29
+- **Discussion:** *(GitHub PR link will go here once opened)*
+
+## Summary
+
+Introduce a `.skills/` directory that captures samlify's contribution
+conventions in machine- and human-readable playbooks. Establish a
+**spec citation workflow** that requires every PR touching `src/` to
+cite the OASIS SAML 2.0 (or W3C XML-DSig / XML-Enc) section the change
+implements, fixes, or extends.
+
+## Motivation
+
+samlify is a SAML 2.0 implementation. The library's correctness is
+defined entirely by external normative documents:
+
+- OASIS SAML 2.0 Core, Bindings, Profiles, Metadata, Conformance, and
+  Security Considerations.
+- W3C XML Signature, XML Encryption, and Canonicalization specs.
+
+Today, contributors and reviewers reason about correctness from memory
+or from prior code. This is fragile:
+
+- Bug reports often turn out to be spec-conformance bugs, but the PR
+  history rarely says so.
+- It is easy to "fix" a perceived bug by introducing behaviour that
+  satisfies one peer and violates the spec for everyone else.
+- New contributors don't have a single place to learn which sections
+  matter and where they're implemented.
+
+A formalised workflow with low ceremony fixes all three problems and
+costs reviewers ~30 seconds per PR.
+
+## Proposal
+
+### `.skills/` directory
+
+Add a top-level `.skills/` directory containing:
+
+| File | Purpose |
+| --- | --- |
+| `README.md` | Index. |
+| `saml-spec-references.md` | Canonical URLs for every normative document samlify touches, plus a **module → spec map** that points each `src/` file at the section(s) it implements. |
+| `spec-citation-workflow.md` | The skill itself: when it applies, what to cite, per-change-type checklists, examples. |
+| `specs/` | Local-only PDF cache. Contents gitignored. |
+
+### PR template
+
+Add `.github/pull_request_template.md` with a required **Spec
+reference** section. The template is enforced socially (reviewers
+block PRs missing it) rather than via a CI gate, so that genuinely
+spec-orthogonal PRs (CI tweaks, dependency bumps) can opt out by
+explaining themselves.
+
+### CONTRIBUTING.md pointer
+
+Add a short pointer from `CONTRIBUTING.md` (creating one if absent) so
+external contributors discover the skill before they open a PR.
+
+## Non-goals
+
+- **Not a CI gate.** False positives would frustrate maintainers more
+  than they would catch real misses. A `block-on-missing-citation`
+  workflow can be added later if review fatigue becomes the bottleneck.
+- **Not a vendored spec corpus.** PDFs are large, copyrighted, and
+  externally hosted. We cite, we don't bundle.
+- **Not a process for non-code PRs.** Tooling, release plumbing, and
+  cosmetic doc fixes don't need citations.
+
+## Alternatives considered
+
+1. **Vendor the spec PDFs into the repo.** Rejected — ~100 MB of
+   binary churn, slow clones, no clear gain over canonical URLs.
+2. **Inline the citations in JSDoc only.** Rejected — JSDoc citations
+   are great but don't surface in PR review or `git log`. The skill
+   complements rather than replaces JSDoc citations.
+3. **Lint rule that requires a `@spec` JSDoc tag on exported
+   functions.** Worth considering as a follow-up once the skill is
+   bedded in. Out of scope for this RFC.
+
+## Migration
+
+- The first PR that lands this RFC ships:
+  - The `.skills/` content.
+  - The PR template.
+  - A short CONTRIBUTING blurb.
+- Existing files are **not** retroactively annotated; the skill applies
+  to PRs opened after merge.
+- The first three PRs to follow the new template should be reviewed
+  with extra care to validate the workflow. If the template proves
+  unwieldy, amend it via a follow-up PR.
+
+## Open questions
+
+1. Should `.skills/` be the canonical name, or should we use
+   `.claude/skills/` (Claude Code's convention) or `docs/playbooks/`?
+   Default: `.skills/` — tool-agnostic, discoverable via `ls`.
+2. Do we want a stub script (`bash .skills/specs/fetch.sh`) to
+   download all PDFs into the local cache? Default: yes, as a
+   follow-up PR after this lands.
+3. Should we require a citation for **bumping a dependency** when the
+   bump is security-driven? Default: no — the bump's CHANGELOG link
+   is sufficient.

--- a/.skills/saml-spec-references.md
+++ b/.skills/saml-spec-references.md
@@ -1,0 +1,79 @@
+# SAML 2.0 — Spec references
+
+Canonical sources every samlify contributor should be able to cite. Anchor
+links point at the OASIS / W3C copies.
+
+## OASIS SAML 2.0 (March 2005, OASIS Standard)
+
+| Short name | Full title | URL |
+| --- | --- | --- |
+| `saml-core` | *Assertions and Protocols for the OASIS Security Assertion Markup Language (SAML) v2.0* | <https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf> |
+| `saml-bindings` | *Bindings for the OASIS Security Assertion Markup Language (SAML) v2.0* | <https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf> |
+| `saml-profiles` | *Profiles for the OASIS Security Assertion Markup Language (SAML) v2.0* | <https://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf> |
+| `saml-metadata` | *Metadata for the OASIS Security Assertion Markup Language (SAML) v2.0* | <https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf> |
+| `saml-conformance` | *Conformance Requirements for SAML v2.0* | <https://docs.oasis-open.org/security/saml/v2.0/saml-conformance-2.0-os.pdf> |
+| `saml-sec-consider` | *Security and Privacy Considerations for SAML v2.0* | <https://docs.oasis-open.org/security/saml/v2.0/saml-sec-consider-2.0-os.pdf> |
+| `saml-glossary` | *Glossary for SAML v2.0* | <https://docs.oasis-open.org/security/saml/v2.0/saml-glossary-2.0-os.pdf> |
+| `saml-authn-context` | *Authentication Context for SAML v2.0* | <https://docs.oasis-open.org/security/saml/v2.0/saml-authn-context-2.0-os.pdf> |
+| `saml-tech-overview` | *SAML v2.0 Technical Overview* (non-normative) | <https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html> |
+| `saml-errata` | *Approved Errata for SAML v2.0* | <https://docs.oasis-open.org/security/saml/v2.0/sstc-saml-approved-errata-2.0.pdf> |
+
+## OASIS post-2.0 deliverables (extensions)
+
+| Short name | Full title | URL |
+| --- | --- | --- |
+| `saml-binding-simplesign` | *SAML 2.0 HTTP-POST-SimpleSign Binding* | <https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-binding-simplesign-cd-04.pdf> |
+| `saml-metadata-iop` | *Metadata Interoperability Profile* | <https://docs.oasis-open.org/security/saml/Post2.0/sstc-metadata-iop-cs-01.pdf> |
+
+## OASIS XSD schemas
+
+Drop into `.skills/specs/` for offline use, or fetch on demand:
+
+| Schema | URL |
+| --- | --- |
+| `saml-schema-protocol-2.0.xsd` | <https://docs.oasis-open.org/security/saml/v2.0/saml-schema-protocol-2.0.xsd> |
+| `saml-schema-assertion-2.0.xsd` | <https://docs.oasis-open.org/security/saml/v2.0/saml-schema-assertion-2.0.xsd> |
+| `saml-schema-metadata-2.0.xsd` | <https://docs.oasis-open.org/security/saml/v2.0/saml-schema-metadata-2.0.xsd> |
+| `saml-schema-x500-2.0.xsd` | <https://docs.oasis-open.org/security/saml/v2.0/saml-schema-x500-2.0.xsd> |
+
+## W3C dependencies (signature, encryption, canonicalization)
+
+| Short name | Full title | URL |
+| --- | --- | --- |
+| `xmldsig-core` | *XML Signature Syntax and Processing Version 1.1* | <https://www.w3.org/TR/xmldsig-core1/> |
+| `xmlenc-core` | *XML Encryption Syntax and Processing Version 1.1* | <https://www.w3.org/TR/xmlenc-core1/> |
+| `xml-c14n` | *Canonical XML Version 1.0* | <https://www.w3.org/TR/xml-c14n> |
+| `xml-exc-c14n` | *Exclusive XML Canonicalization Version 1.0* | <https://www.w3.org/TR/xml-exc-c14n/> |
+| `xml-c14n11` | *Canonical XML Version 1.1* | <https://www.w3.org/TR/xml-c14n11/> |
+
+## Module → spec map (samlify)
+
+The table below maps source modules to the sections they implement. Use
+these anchors when citing in a PR; add a row whenever you introduce or
+move responsibilities between modules.
+
+| samlify path | Implements / governed by |
+| --- | --- |
+| `src/binding-redirect.ts` | `saml-bindings §3.4` (HTTP-Redirect Binding); §3.4.4.1 (signature octet string construction) |
+| `src/binding-post.ts` | `saml-bindings §3.5` (HTTP-POST Binding) |
+| `src/binding-simplesign.ts` | `saml-binding-simplesign` (HTTP-POST-SimpleSign), `saml-bindings §3.5` for the form-post envelope |
+| `src/libsaml.ts` (signing/verification) | `saml-core §5` (SAML and XML Signature Syntax and Processing); `xmldsig-core` |
+| `src/libsaml.ts` (encryption/decryption) | `saml-core §6` (SAML and XML Encryption Syntax and Processing); `xmlenc-core` |
+| `src/libsaml.ts` (`isValidXml`) | `saml-conformance §3` and the OASIS schemas |
+| `src/extractor.ts` | `saml-core §2` (Assertions), §3 (Protocols) — XPath-driven extraction of fields defined therein |
+| `src/flow.ts` | `saml-profiles §4` (SSO Profiles); `saml-bindings` (per-binding processing rules); `saml-core §3.2.2` (StatusResponseType) |
+| `src/metadata.ts` / `metadata-idp.ts` / `metadata-sp.ts` | `saml-metadata` (entire); `saml-metadata-iop` for interop subset |
+| `src/entity-idp.ts` | `saml-profiles §4.1` (Web Browser SSO Profile, IdP role) |
+| `src/entity-sp.ts` | `saml-profiles §4.1` (Web Browser SSO Profile, SP role); `saml-profiles §4.4` (SLO) |
+| `src/validator.ts` | `saml-core §2.5.1.2` (Conditions / NotBefore / NotOnOrAfter); `saml-core §2.7.2.2` (SubjectConfirmationData) |
+| `src/urn.ts` | `saml-core §8` (URI Reference Conventions); `saml-bindings §3` (binding URIs); `saml-profiles §3` (status code URIs) |
+
+## Citation format
+
+Prefer the form `saml-<doc> §<section>` in commit messages, PR bodies,
+and JSDoc comments. Examples:
+
+- `saml-core §5.4.2` — Reference processing rules for assertion signatures.
+- `saml-bindings §3.4.4.1` — Octet string construction for HTTP-Redirect.
+- `saml-profiles §4.1.4.5` — Subject confirmation processing for Web SSO.
+- `xmldsig-core §4.5` — `<KeyInfo>` element.

--- a/.skills/spec-citation-workflow.md
+++ b/.skills/spec-citation-workflow.md
@@ -1,0 +1,147 @@
+# Skill — Spec citation workflow
+
+## Purpose
+
+Make every change to samlify traceable to the SAML 2.0 / W3C normative
+documents it implements, fixes, or extends. This raises the floor on
+review quality, catches accidental drift from the standard, and makes the
+project easier to audit.
+
+## When to apply
+
+Apply this skill when **any** of the following are true:
+
+- The PR touches a file under `src/`.
+- The PR adds, removes, or changes externally observable behaviour
+  (binding output, signature placement, validation rules, error codes).
+- The PR fixes a bug whose root cause is a deviation from the spec.
+- The PR changes documentation that describes spec-defined behaviour.
+
+It does **not** apply to:
+
+- Pure tooling / dev-experience changes (CI, dependencies, lint config,
+  test scaffolding, formatting).
+- Changes outside `src/` and `docs/` (e.g. `.skills/` itself, `README.md`,
+  CONTRIBUTING).
+
+## Procedure
+
+### 1. Identify the relevant spec section(s)
+
+Use [`saml-spec-references.md`](./saml-spec-references.md) — start from
+the **module → spec map**, then narrow down to the smallest section that
+governs the behaviour being changed.
+
+### 2. Cite in the PR description
+
+The PR template enforces a **Spec reference** section. Fill it in with:
+
+```markdown
+## Spec reference
+- `saml-bindings §3.4.4.1` — octet string construction for the
+  HTTP-Redirect binding signature.
+- `xmldsig-core §6.5.1` — RSA-SHA256 algorithm identifier.
+```
+
+If a change is genuinely standards-orthogonal, write *"N/A — internal
+refactor, no observable behaviour change"* and explain why.
+
+### 3. Cite in the commit message
+
+The first body paragraph of the commit message should restate the spec
+reference. Reviewers and `git blame` readers should not need to open the
+PR to see why the code looks the way it does.
+
+### 4. Cite in code (when behaviour is non-obvious)
+
+When the code path implements a specific normative requirement and the
+intent isn't apparent from reading, add a single-line comment:
+
+```ts
+// saml-bindings §3.4.4.1: RelayState is excluded from the octet string
+// when the value is empty.
+```
+
+Do **not** copy spec prose into comments. Cite the section, summarise
+the constraint in your own words, and let the reader follow the link if
+they want depth.
+
+### 5. Tests must pin the cited behaviour
+
+Each new behaviour rule cited in the PR should have at least one test
+that would fail if that rule were violated. The test name should
+mention the rule (e.g. *"omits RelayState from octet string when empty
+(saml-bindings §3.4.4.1)"*).
+
+## Per-change-type checklist
+
+### Feature / new binding / new profile
+
+- [ ] Spec section(s) cited in PR body, commit message, and any
+      non-obvious code.
+- [ ] At least one test per normative MUST/SHOULD requirement
+      introduced.
+- [ ] Module → spec map in `saml-spec-references.md` updated if a new
+      file under `src/` was added.
+- [ ] Conformance impact noted: does this change which profiles the
+      library claims to implement (`saml-conformance`)?
+
+### Bug fix
+
+- [ ] PR body identifies the spec rule the previous code violated.
+- [ ] Regression test references the section in its name.
+- [ ] If the bug surfaced through a SAML peer (Okta, OneLogin, ADFS,
+      etc.), call out the interop case alongside the spec citation.
+
+### Refactor
+
+- [ ] PR body asserts that no spec-observable behaviour changed.
+- [ ] If a refactor *also* fixes a spec deviation it discovered, split
+      the fix into a separate commit so it's reviewable independently.
+- [ ] Test coverage thresholds (`vitest.config.ts`) still pass.
+
+### Security fix
+
+- [ ] Spec section in `saml-sec-consider` cited if applicable.
+- [ ] Threat model paragraph in the PR body: which attack vector is
+      closed.
+- [ ] CHANGELOG / advisory note drafted before the PR is marked ready
+      for review.
+
+### Documentation change
+
+- [ ] If documenting spec-defined behaviour, link to the spec section
+      from the doc page itself, not just the PR.
+
+## Examples
+
+A passing PR body looks like:
+
+> ## Summary
+> Closes #584. Add the `simpleSign` branch to
+> `Entity#createLogoutRequest` and `Entity#createLogoutResponse`.
+>
+> ## Spec reference
+> - `saml-binding-simplesign §2` — HTTP-POST-SimpleSign binding,
+>   octet-string construction and `Signature` form field.
+> - `saml-bindings §3.5` — base form-post envelope inherited by
+>   SimpleSign.
+> - `saml-profiles §4.4` — Single Logout Profile processing rules.
+>
+> ## Test plan
+> - [x] Logout request envelope under simpleSign.
+> - [x] Detached signature emitted when target advertises
+>       `wantLogoutRequestSigned`.
+> - [x] Custom template callback path.
+
+## When the spec is silent or ambiguous
+
+Some behaviour samlify implements is interop-driven rather than
+spec-mandated (e.g. tag-prefix handling for `<EncryptedAssertion>`).
+In those cases:
+
+- Cite the closest related section from the spec.
+- Add a second citation to the IdP/SP behaviour you're matching (e.g.
+  *"Okta interop: encryption namespace prefix `saml:` per
+  https://help.okta.com/..."*).
+- Note in the PR body that the change is interop-driven, not normative.

--- a/.skills/specs/.gitignore
+++ b/.skills/specs/.gitignore
@@ -1,0 +1,6 @@
+# Local-only cache of OASIS SAML 2.0 / W3C normative PDFs and XSDs.
+# These are large, copyrighted-but-redistributable documents.
+# Track only this .gitignore; do not commit downloaded artefacts.
+*
+!.gitignore
+!README.md

--- a/.skills/specs/README.md
+++ b/.skills/specs/README.md
@@ -1,0 +1,23 @@
+# Local spec cache (gitignored)
+
+Drop downloaded PDF / XSD copies of the OASIS SAML 2.0 and W3C normative
+documents here for offline reference. The `.gitignore` in this directory
+ensures they are never committed.
+
+To populate this directory, run the helper script (or copy the URLs from
+[`../saml-spec-references.md`](../saml-spec-references.md)):
+
+```bash
+# from the repo root
+bash .skills/specs/fetch.sh   # if/when added
+```
+
+## Why aren't these vendored in the repo?
+
+- Combined size is ~100 MB across all OASIS + W3C deliverables.
+- They're stable, externally hosted, and have canonical URLs that don't
+  rot. There is no benefit to vendoring them and a real cost to clone
+  size and history bloat.
+- Citations in PRs and commit messages reference section anchors, not
+  byte-level artefacts, so contributors don't need a local copy unless
+  they're working offline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to samlify
+
+Thanks for considering a contribution. samlify is a SAML 2.0 library, so
+**correctness against the OASIS / W3C standards is the primary review
+criterion**. Two short documents capture how we work:
+
+- [`.skills/spec-citation-workflow.md`](./.skills/spec-citation-workflow.md)
+  — what to cite, where, and per-change-type checklists.
+- [`.skills/saml-spec-references.md`](./.skills/saml-spec-references.md)
+  — canonical URLs for every normative document and a module → spec map.
+
+The PR template (auto-loaded from `.github/pull_request_template.md`)
+includes a required **Spec reference** section. Fill it in for any PR
+touching `src/`.
+
+## Quick start
+
+```bash
+yarn
+yarn test
+yarn coverage   # must stay ≥90% on every metric
+```
+
+## Bug reports and questions
+
+Please open an issue with:
+
+- The samlify version (`npm ls samlify`).
+- The peer IdP / SP product if relevant (Okta, OneLogin, ADFS, …).
+- A minimal repro and the relevant SAML message (redact secrets).
+- The spec section you believe applies, if you've identified one.


### PR DESCRIPTION
> ⚠️ Drafted as an RFC. Goal is discussion before merge — please leave review comments on prose, scope, and process before approving.

## Summary

Adds a top-level \`.skills/\` directory of contribution playbooks for
samlify, plus a PR template that requires a **Spec reference** section
on any PR touching \`src/\`.

The full proposal text lives at [\`.skills/RFC-0001-spec-citation.md\`](../tree/rfc/0001-spec-citation-skills/.skills/RFC-0001-spec-citation.md). Highlights below.

## Why

samlify's correctness is defined by the OASIS SAML 2.0 specs and the
W3C XML-DSig / XML-Enc / canonicalization specs. Today, that lineage
is implicit: a reviewer must reason from memory or prior code to
decide whether a change is correct. That works against:

- maintainability — \`git blame\` rarely tells you *why* the code is the way it is;
- review quality — easy to accept changes that satisfy one IdP / SP and break the spec;
- onboarding — new contributors have no map of which sections matter.

The proposal raises the floor on all three for ~30 seconds of
reviewer effort per PR.

## What this PR ships

| Path | Purpose |
| --- | --- |
| \`.skills/README.md\` | Index of skills. |
| \`.skills/saml-spec-references.md\` | Canonical URLs for every normative document samlify touches, plus a **module → spec map** that points each \`src/\` file at the section(s) it implements. |
| \`.skills/spec-citation-workflow.md\` | The skill itself — when it applies, what to cite, per-change-type checklists (feature / bug fix / refactor / security / docs), and a worked example based on PR #608. |
| \`.skills/RFC-0001-spec-citation.md\` | Proposal text (this RFC). |
| \`.skills/specs/\` | Local-only PDF cache; contents gitignored. |
| \`.github/pull_request_template.md\` | Required *Spec reference* section. |
| \`CONTRIBUTING.md\` | New file pointing external contributors at the skill. |

## What this PR does **not** ship

- No CI gate. Enforcement is social — reviewers block PRs missing the section.
- No vendored spec PDFs. ~100 MB of binary churn; canonical URLs are stable.
- No retroactive annotation of existing modules. Skill applies to PRs opened after merge.

## Spec reference

N/A — this PR adds project process, not SAML behaviour.

## Test plan

- [x] \`yarn test\` still passes (228 / 1 skipped) — no source code touched.
- [x] \`yarn coverage\` thresholds (≥90% on stmts / branches / funcs / lines) still pass.
- [ ] Maintainer review of prose tone and scope (open question 1 in the RFC: \`.skills/\` vs \`.claude/skills/\` vs \`docs/playbooks/\`).
- [ ] Maintainer decision on whether to ship a \`fetch.sh\` helper now or in a follow-up (RFC open question 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)