### PR TITLE
fix: omit AuthnRequest attributes whose value is null/undefined (closes #455)

### DIFF
--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -328,15 +328,36 @@ const libSaml = () => {
      * Substitute `{Tag}` placeholders inside an XML template with the given
      * replacement map. Attribute values are XML-escaped; element text is not.
      *
+     * When a tag's value is `null` or `undefined`:
+     *   - in **attribute position** (`name="{Tag}"`) the entire attribute is
+     *     omitted from the rendered XML, per `saml-core §3.4.1` (every
+     *     `<AuthnRequest>` attribute is `use="optional"`); previously samlify
+     *     emitted `name=""` or the literal `name="undefined"`, which is
+     *     invalid for typed attributes (e.g. `AssertionConsumerServiceURL`
+     *     declared as `xs:anyURI`).
+     *   - in **element-text position** (`<X>{Tag}</X>`) the placeholder is
+     *     replaced with the empty string (legacy behaviour preserved).
+     *
      * @param rawXML template with `{Tag}` placeholders
      * @param tagValues replacement map keyed by tag name
      * @returns XML with placeholders resolved
      */
     replaceTagsByValue(rawXML: string, tagValues: TagReplacementMap): string {
       Object.keys(tagValues).forEach(t => {
+        const value = tagValues[t];
+        if (value === null || value === undefined) {
+          // Drop the entire `\s+name="{Tag}"` (or single-quoted) attribute.
+          rawXML = rawXML.replace(
+            new RegExp(`\\s+[A-Za-z_:][\\w:.-]*=("|')\\{${t}\\}\\1`, 'g'),
+            '',
+          );
+          // Replace any element-text occurrence with empty string.
+          rawXML = rawXML.replace(new RegExp(`\\{${t}\\}`, 'g'), '');
+          return;
+        }
         rawXML = rawXML.replace(
           new RegExp(`("?)\\{${t}\\}`, 'g'),
-          escapeTag(tagValues[t]),
+          escapeTag(value),
         );
       });
       return rawXML;

--- a/test/units.ts
+++ b/test/units.ts
@@ -240,12 +240,31 @@ describe('libsaml — pure helpers', () => {
     expect(xml).toBe('<a id="a&amp;b"><x/></a>');
   });
 
-  test('replaceTagsByValue treats null and undefined as empty strings', () => {
+  test('replaceTagsByValue omits attributes whose value is null or undefined (#455, saml-core §3.4.1)', () => {
+    // null/undefined in attribute position drop the whole attribute; in
+    // element-text position they collapse to the empty string.
     const xml = libsaml.replaceTagsByValue(
       '<a id="{Id}">{Body}</a>',
       { Id: null, Body: undefined },
     );
-    expect(xml).toBe('<a id=""></a>');
+    expect(xml).toBe('<a></a>');
+  });
+
+  test('replaceTagsByValue keeps explicit empty-string attributes', () => {
+    // Empty string is a legitimate value and should NOT trigger omission.
+    const xml = libsaml.replaceTagsByValue(
+      '<a id="{Id}"/>',
+      { Id: '' },
+    );
+    expect(xml).toBe('<a id=""/>');
+  });
+
+  test('replaceTagsByValue omits only the attribute whose tag is missing', () => {
+    const xml = libsaml.replaceTagsByValue(
+      '<a foo="x" bar="{Y}" baz="z"/>',
+      { Y: undefined },
+    );
+    expect(xml).toBe('<a foo="x" baz="z"/>');
   });
 
   test('attributeStatementBuilder renders attributes with defaults', () => {
@@ -872,6 +891,44 @@ describe('Security audit (2026-04)', () => {
         'http://attacker.example.com/madeup-alg',
       ),
     ).toThrow('ERR_UNSUPPORTED_SIGNATURE_ALGORITHM');
+  });
+});
+
+describe('AuthnRequest attribute omission (#455, saml-core §3.4.1)', () => {
+  // saml-core §3.4.1 declares ACS URL, NameIDPolicy/Format, AllowCreate
+  // (and friends) as `use="optional"`. If samlify can't fill them in, it
+  // must omit the attribute rather than emit `name=""` or `name="undefined"`.
+
+  test('default AuthnRequest template drops AssertionConsumerServiceURL when value is undefined', () => {
+    const xml = libsaml.replaceTagsByValue(libsaml.defaultLoginRequestTemplate.context, {
+      ID: '_x',
+      Destination: 'https://idp/sso',
+      Issuer: 'https://sp/meta',
+      IssueInstant: '2026-05-01T00:00:00Z',
+      AssertionConsumerServiceURL: undefined,
+      NameIDFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+      AllowCreate: false,
+    });
+    expect(xml).not.toContain('AssertionConsumerServiceURL=""');
+    expect(xml).not.toContain('AssertionConsumerServiceURL="undefined"');
+    expect(xml).not.toContain('AssertionConsumerServiceURL=');
+  });
+
+  test('default AuthnRequest template drops NameIDFormat and AllowCreate when both are undefined', () => {
+    const xml = libsaml.replaceTagsByValue(libsaml.defaultLoginRequestTemplate.context, {
+      ID: '_x',
+      Destination: 'https://idp/sso',
+      Issuer: 'https://sp/meta',
+      IssueInstant: '2026-05-01T00:00:00Z',
+      AssertionConsumerServiceURL: 'https://sp/acs',
+      NameIDFormat: undefined,
+      AllowCreate: undefined,
+    });
+    expect(xml).not.toContain('Format=');
+    expect(xml).not.toContain('AllowCreate=');
+    // The NameIDPolicy element itself remains (saml-core §3.4.1 allows it
+    // with no attributes).
+    expect(xml).toContain('<samlp:NameIDPolicy');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #455.

\`libsaml.replaceTagsByValue\` previously substituted \`null\`/\`undefined\` tag values with the empty string. In attribute position that produced \`AssertionConsumerServiceURL=\"\"\` (or, when callers pre-stringified, \`AssertionConsumerServiceURL=\"undefined\"\`) — both invalid per the schema in saml-core §3.4.1, where \`AssertionConsumerServiceURL\` is typed \`xs:anyURI\` (which rejects the literal \"undefined\") and declared \`use=\"optional\"\`.

This PR changes the substitution behaviour:

- **Attribute position** (\`name=\"{Tag}\"\` / \`name='{Tag}'\`) — when the value is \`null\`/\`undefined\`, the entire \`\\s+name=\"...\"\` is dropped from the rendered XML.
- **Element-text position** (\`<X>{Tag}</X>\`) — unchanged: replaced with the empty string. (\`<X></X>\` is valid where the element itself is optional.)
- **Explicit empty string** \`\"\" \` — preserved unchanged. Empty string is a legitimate attribute value and should not trigger omission.

Per saml-profiles §4.1.4.1, omitting \`AssertionConsumerServiceURL\` is the intended way to delegate ACS endpoint selection to the IdP via SP-metadata defaults — so this isn't just a render fix, it's the spec-aligned behaviour the SP needs to express \"use my default ACS\".

## Spec reference

- \`saml-core §3.4.1\` — \`<AuthnRequest>\` attributes are all \`use=\"optional\"\`; \`AssertionConsumerServiceURL\` / \`AssertionConsumerServiceIndex\` / \`ProtocolBinding\` are mutually exclusive.
- \`saml-profiles §4.1.4.1\` — IdP fallback to SP-metadata default ACS when the request omits the URL.

## Test plan

- [x] \`replaceTagsByValue omits attributes whose value is null or undefined\` — unit-level.
- [x] \`replaceTagsByValue keeps explicit empty-string attributes\` — regression.
- [x] \`replaceTagsByValue omits only the attribute whose tag is missing\` — neighbours survive.
- [x] \`default AuthnRequest template drops AssertionConsumerServiceURL when value is undefined\` — pins the #455 fix against the actual shipped template.
- [x] \`default AuthnRequest template drops NameIDFormat and AllowCreate when both are undefined\` — \`<samlp:NameIDPolicy />\` element itself is retained (allowed by §3.4.1).
- [x] Full suite: 256 / 1 skipped pass.
- [x] Coverage thresholds (≥90% on every metric) hold: 97.22% / 90.01% / 99.14% / 97.22%.

## Behaviour change

Callers that previously relied on \`name=\"\"\` being emitted for absent values will now see the attribute omitted entirely. This matches the spec — we don't expect any caller to depend on the old buggy output — but it's worth flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)