### PR TITLE
fix: pass SessionIndex through createLogoutRequest (closes #470)

### DIFF
--- a/src/binding-post.ts
+++ b/src/binding-post.ts
@@ -281,6 +281,9 @@ function base64LogoutRequest(
       EntityID: metadata.init.getEntityID(),
       NameIDFormat: selectedNameIDFormat,
       NameID: user.logoutNameID,
+      // saml-core §3.7.1 — SessionIndex is optional; replaceTagsByValue
+      // drops the element when undefined (closes #470).
+      SessionIndex: user.sessionIndex,
     };
     rawSamlRequest = libsaml.replaceTagsByValue(libsaml.defaultLogoutRequestTemplate.context, tvalue);
   }

--- a/src/binding-simplesign.ts
+++ b/src/binding-simplesign.ts
@@ -298,6 +298,9 @@ function base64LogoutRequest(
       EntityID: metadata.init.getEntityID(),
       NameIDFormat: selectedNameIDFormat,
       NameID: user.logoutNameID,
+      // saml-core §3.7.1 — SessionIndex is optional; replaceTagsByValue
+      // drops the element when undefined (closes #470).
+      SessionIndex: user.sessionIndex,
     };
     rawSamlRequest = libsaml.replaceTagsByValue(libsaml.defaultLogoutRequestTemplate.context, tvalue);
   }

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -205,9 +205,17 @@ const libSaml = () => {
     context: '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" IssueInstant="{IssueInstant}" Destination="{Destination}" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="{AssertionConsumerServiceURL}"><saml:Issuer>{Issuer}</saml:Issuer><samlp:NameIDPolicy Format="{NameIDFormat}" AllowCreate="{AllowCreate}"/></samlp:AuthnRequest>',
   };
 
-  /** Default LogoutRequest XML template. */
+  /**
+   * Default LogoutRequest XML template.
+   *
+   * The optional `<samlp:SessionIndex>` element (saml-core §3.7.1) is
+   * included with a placeholder body. When the caller leaves
+   * `user.sessionIndex` undefined, `replaceTagsByValue` drops the whole
+   * element from the rendered XML, matching the schema's
+   * `minOccurs="0"` declaration.
+   */
   const defaultLogoutRequestTemplate: LogoutRequestTemplate = {
-    context: '<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" IssueInstant="{IssueInstant}" Destination="{Destination}"><saml:Issuer>{Issuer}</saml:Issuer><saml:NameID Format="{NameIDFormat}">{NameID}</saml:NameID></samlp:LogoutRequest>',
+    context: '<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" IssueInstant="{IssueInstant}" Destination="{Destination}"><saml:Issuer>{Issuer}</saml:Issuer><saml:NameID Format="{NameIDFormat}">{NameID}</saml:NameID><samlp:SessionIndex>{SessionIndex}</samlp:SessionIndex></samlp:LogoutRequest>',
   };
 
   /** Default AttributeStatement XML fragment template. */
@@ -335,8 +343,12 @@ const libSaml = () => {
      *     emitted `name=""` or the literal `name="undefined"`, which is
      *     invalid for typed attributes (e.g. `AssertionConsumerServiceURL`
      *     declared as `xs:anyURI`).
-     *   - in **element-text position** (`<X>{Tag}</X>`) the placeholder is
-     *     replaced with the empty string (legacy behaviour preserved).
+     *   - in **element-only-body position** (`<X>{Tag}</X>` or
+     *     `<X attr="...">{Tag}</X>`) the entire element is dropped — per
+     *     `saml-core §3.7.1` for `<samlp:SessionIndex>` and any other
+     *     `minOccurs="0"` element where the body is solely a placeholder.
+     *   - in **mixed-text position** (`<X>prefix{Tag}suffix</X>`) the
+     *     placeholder is replaced with the empty string (legacy behaviour).
      *
      * @param rawXML template with `{Tag}` placeholders
      * @param tagValues replacement map keyed by tag name
@@ -351,7 +363,14 @@ const libSaml = () => {
             new RegExp(`\\s+[A-Za-z_:][\\w:.-]*=("|')\\{${t}\\}\\1`, 'g'),
             '',
           );
-          // Replace any element-text occurrence with empty string.
+          // Drop the entire `<X ...>{Tag}</X>` element when the placeholder
+          // is the only body content (allows optional elements to be omitted
+          // rather than rendered empty).
+          rawXML = rawXML.replace(
+            new RegExp(`<([A-Za-z_:][\\w:.-]*)((?:\\s+[^>]*)?)>\\{${t}\\}</\\1>`, 'g'),
+            '',
+          );
+          // Replace any remaining `{Tag}` occurrences with empty string.
           rawXML = rawXML.replace(new RegExp(`\\{${t}\\}`, 'g'), '');
           return;
         }

--- a/test/units.ts
+++ b/test/units.ts
@@ -241,13 +241,32 @@ describe('libsaml — pure helpers', () => {
   });
 
   test('replaceTagsByValue omits attributes whose value is null or undefined (#455, saml-core §3.4.1)', () => {
-    // null/undefined in attribute position drop the whole attribute; in
-    // element-text position they collapse to the empty string.
+    // null/undefined in attribute position drop the whole attribute. When
+    // the body of the element is also a placeholder that resolves to
+    // null/undefined, the entire element is dropped (saml-core §3.7.1
+    // covers the same rule for `<samlp:SessionIndex>`).
     const xml = libsaml.replaceTagsByValue(
       '<a id="{Id}">{Body}</a>',
       { Id: null, Body: undefined },
     );
-    expect(xml).toBe('<a></a>');
+    // Both the attribute and the body are absent → entire element drops.
+    expect(xml).toBe('');
+  });
+
+  test('replaceTagsByValue keeps the element when only the attribute is absent', () => {
+    const xml = libsaml.replaceTagsByValue(
+      '<a id="{Id}">visible</a>',
+      { Id: null },
+    );
+    expect(xml).toBe('<a>visible</a>');
+  });
+
+  test('replaceTagsByValue drops only the placeholder in mixed-text content', () => {
+    const xml = libsaml.replaceTagsByValue(
+      '<a>before-{Tag}-after</a>',
+      { Tag: undefined },
+    );
+    expect(xml).toBe('<a>before--after</a>');
   });
 
   test('replaceTagsByValue keeps explicit empty-string attributes', () => {
@@ -891,6 +910,119 @@ describe('Security audit (2026-04)', () => {
         'http://attacker.example.com/madeup-alg',
       ),
     ).toThrow('ERR_UNSUPPORTED_SIGNATURE_ALGORITHM');
+  });
+});
+
+describe('LogoutRequest SessionIndex (#470, saml-core §3.7.1)', () => {
+  // saml-core §3.7.1 — `<samlp:SessionIndex>` is `minOccurs="0"`, so it
+  // must appear when the SP knows the session index, and must be absent
+  // otherwise. Previously the bindings either dropped the field entirely
+  // or omitted it from the template.
+
+  test('default LogoutRequest template includes SessionIndex when supplied', () => {
+    const xml = libsaml.replaceTagsByValue(libsaml.defaultLogoutRequestTemplate.context, {
+      ID: '_x',
+      Destination: 'https://idp/slo',
+      Issuer: 'https://sp/meta',
+      IssueInstant: '2026-05-01T00:00:00Z',
+      NameIDFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+      NameID: 'user@example.com',
+      SessionIndex: '_session-abc',
+    });
+    expect(xml).toContain('<samlp:SessionIndex>_session-abc</samlp:SessionIndex>');
+  });
+
+  test('default LogoutRequest template drops SessionIndex when not supplied', () => {
+    const xml = libsaml.replaceTagsByValue(libsaml.defaultLogoutRequestTemplate.context, {
+      ID: '_x',
+      Destination: 'https://idp/slo',
+      Issuer: 'https://sp/meta',
+      IssueInstant: '2026-05-01T00:00:00Z',
+      NameIDFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+      NameID: 'user@example.com',
+      SessionIndex: undefined,
+    });
+    expect(xml).not.toContain('SessionIndex');
+    expect(xml).not.toContain('<samlp:SessionIndex');
+  });
+
+  test('createLogoutRequest (post): user.sessionIndex surfaces in the rendered XML', () => {
+    const idp = identityProvider({
+      privateKey: fs.readFileSync('./test/key/idp/privkey.pem'),
+      privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+      metadata: idpMetaXml,
+    });
+    const sp = serviceProvider({
+      privateKey: fs.readFileSync('./test/key/sp/privkey.pem'),
+      privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+      metadata: spMetaXml,
+    });
+    const result = idp.createLogoutRequest(sp, 'post', {
+      logoutNameID: 'u@x',
+      sessionIndex: '_session-post-1',
+    });
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).toContain('<samlp:SessionIndex>_session-post-1</samlp:SessionIndex>');
+  });
+
+  test('createLogoutRequest (redirect): user.sessionIndex surfaces in the rendered XML', () => {
+    const idp = identityProvider({
+      privateKey: fs.readFileSync('./test/key/idp/privkey.pem'),
+      privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+      metadata: idpMetaXml,
+    });
+    const sp = serviceProvider({
+      privateKey: fs.readFileSync('./test/key/sp/privkey.pem'),
+      privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+      metadata: spMetaXml,
+    });
+    const result = idp.createLogoutRequest(sp, 'redirect', {
+      logoutNameID: 'u@x',
+      sessionIndex: '_session-redirect-1',
+    });
+    const url = new URL(result.context, 'http://example.test');
+    const inflated = require('zlib').inflateRawSync(
+      Buffer.from(decodeURIComponent(url.searchParams.get('SAMLRequest')!), 'base64'),
+    ).toString('utf8');
+    expect(inflated).toContain('<samlp:SessionIndex>_session-redirect-1</samlp:SessionIndex>');
+  });
+
+  test('createLogoutRequest (simpleSign): user.sessionIndex surfaces in the rendered XML', () => {
+    const idp = identityProvider({
+      privateKey: fs.readFileSync('./test/key/idp/privkey.pem'),
+      privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+      metadata: idpMetaXml,
+    });
+    const sp = serviceProvider({
+      privateKey: fs.readFileSync('./test/key/sp/privkey.pem'),
+      privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+      metadata: spMetaXml,
+    });
+    const result = idp.createLogoutRequest(sp, 'simpleSign', {
+      logoutNameID: 'u@x',
+      sessionIndex: '_session-ss-1',
+    });
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).toContain('<samlp:SessionIndex>_session-ss-1</samlp:SessionIndex>');
+  });
+
+  test('createLogoutRequest (post): no SessionIndex element when sessionIndex is omitted', () => {
+    const idp = identityProvider({
+      privateKey: fs.readFileSync('./test/key/idp/privkey.pem'),
+      privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+      metadata: idpMetaXml,
+    });
+    const sp = serviceProvider({
+      privateKey: fs.readFileSync('./test/key/sp/privkey.pem'),
+      privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+      metadata: spMetaXml,
+    });
+    const result = idp.createLogoutRequest(sp, 'post', {
+      logoutNameID: 'u@x',
+      // sessionIndex intentionally omitted
+    });
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).not.toContain('<samlp:SessionIndex');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #470.

\`createLogoutRequest\` accepted \`user.sessionIndex\` but never rendered it in any binding output:

- The default \`defaultLogoutRequestTemplate\` (libsaml.ts) had no \`{SessionIndex}\` placeholder.
- \`binding-post.ts\` and \`binding-simplesign.ts\` did not pass \`SessionIndex\` into their tag maps at all.
- \`binding-redirect.ts\` did pass \`SessionIndex: user.sessionIndex\`, but the placeholder didn't exist in the template, so the value was silently dropped.

End result: any SP-initiated SLO that requires \`SessionIndex\` was malformed.

## Spec reference

- \`saml-core §3.7.1\` — \`<samlp:LogoutRequest>\` schema declares \`<samlp:SessionIndex>\` as \`minOccurs=\"0\" maxOccurs=\"unbounded\"\`. The element is optional but, when known, the SP "SHOULD include the SessionIndex of the session being terminated".
- \`saml-profiles §4.4\` — SP-initiated Single Logout uses SessionIndex to identify the session being terminated.

## Changes

1. Added \`<samlp:SessionIndex>{SessionIndex}</samlp:SessionIndex>\` to \`defaultLogoutRequestTemplate\`.
2. Added \`SessionIndex: user.sessionIndex\` to the tag map in both \`binding-post.base64LogoutRequest\` and \`binding-simplesign.base64LogoutRequest\` (binding-redirect already had it).
3. Extended \`replaceTagsByValue\` with **element-position omission**: when an element's body is solely a placeholder that resolves to null/undefined, the entire \`<X ...>{Tag}</X>\` is dropped from the rendered XML. This is what makes the optional-element contract from saml-core §3.7.1 work end-to-end without bindings having to special-case the empty-SessionIndex render.

## Test plan

- [x] Default template includes/omits \`<samlp:SessionIndex>\` based on input.
- [x] \`createLogoutRequest\` for **all three bindings** (redirect / post / simpleSign) emits the SessionIndex element when supplied.
- [x] \`createLogoutRequest\` (post) omits the SessionIndex element entirely when \`user.sessionIndex\` is absent.
- [x] Two regression tests for the broader \`replaceTagsByValue\` element-omission rule (preserves elements when only an attribute is absent; preserves placeholder-only-replacement in mixed-text content).
- [x] Full suite: 264 / 1 skipped pass.
- [x] Coverage thresholds (≥90% on every metric) still pass: 97.23% / 90.01% / 99.14% / 97.23%.

## Behaviour change

Templates whose element-body is solely a placeholder will see the entire element dropped when the value is null/undefined, where they previously rendered an empty element. This matches the spec for optional elements (SessionIndex, EncryptedID, etc.). Required elements (NameID in LogoutRequest, Audience inside AudienceRestriction) were already malformed when the value was absent — dropping vs. emitting an empty element is no worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)