### PR TITLE
fix: throw a clear error when redirect binding has no SSO/SLO endpoint (closes #308 #405)

### DIFF
--- a/src/binding-redirect.ts
+++ b/src/binding-redirect.ts
@@ -111,6 +111,14 @@ function loginRequestRedirectURL(
   /* v8 ignore stop */
 
   const base = metadata.idp.getSingleSignOnService(binding.redirect);
+  // saml-bindings §3.4 / saml-metadata §2.4.3: the IdP must declare a
+  // <SingleSignOnService> entry with the HTTP-Redirect Binding URI.
+  // When that endpoint is absent, getSingleSignOnService returns the raw
+  // service map (an object) rather than a URL string — surface a clear
+  // error instead of letting it crash inside url.parse downstream.
+  if (typeof base !== 'string') {
+    throw new Error('ERR_NO_REDIRECT_SSO_ENDPOINT');
+  }
   let rawSamlRequest: string;
   if (spSetting.loginRequestTemplate && customTagReplacement) {
     const info = customTagReplacement(spSetting.loginRequestTemplate as unknown as string);
@@ -182,6 +190,14 @@ function loginResponseRedirectURL(
   /* v8 ignore stop */
 
   const base = metadata.sp.getAssertionConsumerService(binding.redirect);
+  // saml-bindings §3.4 / saml-metadata §2.4.3: the SP must declare an
+  // <AssertionConsumerService> entry with the HTTP-Redirect Binding URI.
+  // When that endpoint is absent, getAssertionConsumerService returns
+  // undefined or the raw service list — reject with a clear error rather
+  // than crashing in url.parse.
+  if (typeof base !== 'string') {
+    throw new Error('ERR_NO_REDIRECT_SSO_ENDPOINT');
+  }
   let rawSamlResponse: string;
   const nameIDFormat = idpSetting.nameIDFormat;
   const selectedNameIDFormat = Array.isArray(nameIDFormat) ? nameIDFormat[0] : nameIDFormat;
@@ -282,6 +298,12 @@ function logoutRequestRedirectURL(
   /* v8 ignore stop */
 
   const base = metadata.target.getSingleLogoutService(binding.redirect);
+  // saml-bindings §3.4 / saml-metadata §2.4.3: the target entity must declare
+  // a <SingleLogoutService> with the HTTP-Redirect Binding URI. Otherwise the
+  // service map leaks through and crashes inside url.parse downstream.
+  if (typeof base !== 'string') {
+    throw new Error('ERR_NO_REDIRECT_SLO_ENDPOINT');
+  }
   let rawSamlRequest = '';
   const requiredTags = {
     ID: id,
@@ -342,6 +364,12 @@ function logoutResponseRedirectURL(
   /* v8 ignore stop */
 
   const base = metadata.target.getSingleLogoutService(binding.redirect);
+  // saml-bindings §3.4 / saml-metadata §2.4.3: same constraint as the
+  // logout request path — the target must advertise a HTTP-Redirect SLO
+  // endpoint before we can build a URL.
+  if (typeof base !== 'string') {
+    throw new Error('ERR_NO_REDIRECT_SLO_ENDPOINT');
+  }
   let rawSamlResponse: string;
   if (initSetting.logoutResponseTemplate && customTagReplacement) {
     const template = customTagReplacement(initSetting.logoutResponseTemplate as unknown as string);

--- a/test/units.ts
+++ b/test/units.ts
@@ -1263,3 +1263,81 @@ describe('Per-request relayState (#163)', () => {
     });
   });
 });
+
+describe('Redirect binding endpoint discovery (closes #308 #405, saml-bindings §3.4 / saml-metadata §2.4.3)', () => {
+  // Both issues report a TypeError thrown deep inside url.parse when the
+  // peer's metadata declares no HTTP-Redirect endpoint. The fix is a
+  // type-guard at the top of each redirect builder: when
+  // getSingleSignOnService / getSingleLogoutService falls through to the
+  // raw service map (an object), throw a clear named error instead.
+
+  test('SP createLoginRequest(redirect) throws ERR_NO_REDIRECT_SSO_ENDPOINT when IdP advertises no HTTP-Redirect SSO', () => {
+    // IdP built from options with only an HTTP-POST SingleSignOnService —
+    // no HTTP-Redirect entry, mirroring the metadata reported in #308.
+    // The SP's spmeta.xml has AuthnRequestsSigned="true", so the IdP must
+    // set wantAuthnRequestsSigned to avoid the unrelated signed-flag conflict.
+    const idpPostOnly = identityProvider({
+      wantAuthnRequestsSigned: true,
+      isAssertionEncrypted: false,
+      singleSignOnService: [{
+        Binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        Location: 'https://idp.example.org/sso/post',
+      }],
+    });
+    const sp = serviceProvider({
+      privateKey: fs.readFileSync('./test/key/sp/privkey.pem'),
+      privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+      metadata: spMetaXml,
+    });
+    expect(() => sp.createLoginRequest(idpPostOnly, 'redirect')).toThrow('ERR_NO_REDIRECT_SSO_ENDPOINT');
+  });
+
+  test('IdP createLogoutRequest(redirect) throws ERR_NO_REDIRECT_SLO_ENDPOINT when SP advertises no HTTP-Redirect SLO', () => {
+    // SP built from options with only an HTTP-POST SingleLogoutService —
+    // mirrors the logout-side variant of the same root cause (#405).
+    const idp = identityProvider({
+      privateKey: fs.readFileSync('./test/key/idp/privkey.pem'),
+      privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+      metadata: idpMetaXml,
+    });
+    const spPostOnlySlo = serviceProvider({
+      entityID: 'https://sp.example.org/metadata',
+      privateKey: fs.readFileSync('./test/key/sp/privkey.pem'),
+      privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+      assertionConsumerService: [{
+        Binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        Location: 'https://sp.example.org/sp/sso',
+      }],
+      singleLogoutService: [{
+        Binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        Location: 'https://sp.example.org/sp/slo',
+      }],
+    });
+    expect(() => idp.createLogoutRequest(spPostOnlySlo, 'redirect', { logoutNameID: 'u@x' }))
+      .toThrow('ERR_NO_REDIRECT_SLO_ENDPOINT');
+  });
+
+  test('IdP createLogoutResponse(redirect) throws ERR_NO_REDIRECT_SLO_ENDPOINT when SP advertises no HTTP-Redirect SLO', () => {
+    const idp = identityProvider({
+      privateKey: fs.readFileSync('./test/key/idp/privkey.pem'),
+      privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+      metadata: idpMetaXml,
+    });
+    const spPostOnlySlo = serviceProvider({
+      entityID: 'https://sp.example.org/metadata',
+      privateKey: fs.readFileSync('./test/key/sp/privkey.pem'),
+      privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+      assertionConsumerService: [{
+        Binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        Location: 'https://sp.example.org/sp/sso',
+      }],
+      singleLogoutService: [{
+        Binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        Location: 'https://sp.example.org/sp/slo',
+      }],
+    });
+    const requestInfo = { extract: { request: { id: '_abc' } } } as any;
+    expect(() => idp.createLogoutResponse(spPostOnlySlo, requestInfo, 'redirect', 'state'))
+      .toThrow('ERR_NO_REDIRECT_SLO_ENDPOINT');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #308 and #405. Both issues report the same crash when the peer's metadata does not declare an HTTP-Redirect endpoint:

```
TypeError: The "url" argument must be of type string. Received type/instance of Object
    at url.parse(...)
    at buildRedirectURL(...)
```

Root cause: `metadata.idp.getSingleSignOnService('redirect')` (and the SLO variant) falls through to returning the raw service map (an object) when no matching binding is registered, and that object was passed straight to `url.parse` inside `buildRedirectURL`. This change adds a type guard at the top of each of the four redirect builders and throws a clear, named error instead. Working setups are unaffected; only the error path is improved.

## Spec reference

- `saml-bindings §3.4` — HTTP-Redirect binding requires a `<SingleSignOnService>` / `<SingleLogoutService>` declared with the redirect Binding URI.
- `saml-metadata §2.4.3` — IdP descriptors MUST list each binding they support; SP descriptors do the same for `<AssertionConsumerService>` / `<SingleLogoutService>`.

The library claims to support the HTTP-Redirect binding only when the peer has advertised a redirect endpoint per these sections. When the advertisement is missing, refuse with a named error instead of crashing inside `url.parse`.

## What changed

- `src/binding-redirect.ts`
  - `loginRequestRedirectURL` — throw `ERR_NO_REDIRECT_SSO_ENDPOINT` when the IdP has no `<SingleSignOnService>` redirect URL.
  - `loginResponseRedirectURL` — throw `ERR_NO_REDIRECT_SSO_ENDPOINT` when the SP has no `<AssertionConsumerService>` redirect URL.
  - `logoutRequestRedirectURL` — throw `ERR_NO_REDIRECT_SLO_ENDPOINT` when the target has no `<SingleLogoutService>` redirect URL.
  - `logoutResponseRedirectURL` — same guard, same error name as the request side.
- `test/units.ts` — three regression tests covering the SSO and SLO paths.

## Test plan

- [x] `yarn test` — 267 tests pass (3 new).
- [x] `yarn coverage` — branches 90.15%, statements 97.21%, functions 99.14%, lines 97.21% (all metrics ≥ 90% threshold; coverage actually improved over master, which was at 89.98% branches before this change).
- [x] `npx tsc` — clean.
- [x] Existing happy-path tests still pass: `idp.createLogoutRequest(sp, 'redirect', ...)` against `spmeta.xml` / `idpmeta.xml` (which both advertise HTTP-Redirect) is untouched.
- [x] New regression: `sp.createLoginRequest(idpPostOnly, 'redirect')` throws `ERR_NO_REDIRECT_SSO_ENDPOINT` instead of a `TypeError` from `url.parse`.
- [x] New regression: `idp.createLogoutRequest(spPostOnlySlo, 'redirect', user)` throws `ERR_NO_REDIRECT_SLO_ENDPOINT`.
- [x] New regression: `idp.createLogoutResponse(spPostOnlySlo, requestInfo, 'redirect', 'state')` throws `ERR_NO_REDIRECT_SLO_ENDPOINT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)