### PR TITLE
feat: per-request ForceAuthn for createLoginRequest (closes #359)

### DIFF
--- a/src/binding-post.ts
+++ b/src/binding-post.ts
@@ -39,12 +39,14 @@ interface PostInitTargetPair {
  * @param referenceTagXPath XPath used when signing the request
  * @param entity `{ idp, sp }` handles
  * @param customTagReplacement optional custom template transformer
+ * @param forceAuthn per-request `ForceAuthn` flag (saml-core §3.4.1)
  * @returns id / base64-XML pair
  */
 function base64LoginRequest(
   referenceTagXPath: string,
   entity: PostIdpSpPair,
   customTagReplacement?: (template: string) => BindingContext,
+  forceAuthn?: boolean,
 ): BindingContext {
   const metadata = { idp: entity.idp.entityMeta, sp: entity.sp.entityMeta };
   const spSetting = entity.sp.entitySetting;
@@ -75,6 +77,9 @@ function base64LoginRequest(
       EntityID: metadata.sp.getEntityID(),
       AllowCreate: spSetting.allowCreate,
       NameIDFormat: selectedNameIDFormat,
+      // saml-core §3.4.1 — `replaceTagsByValue` drops the attribute when
+      // `forceAuthn` is undefined, matching `use="optional"`.
+      ForceAuthn: forceAuthn,
     };
     rawSamlRequest = libsaml.replaceTagsByValue(libsaml.defaultLoginRequestTemplate.context, tags);
   }

--- a/src/binding-redirect.ts
+++ b/src/binding-redirect.ts
@@ -93,12 +93,14 @@ function buildRedirectURL(opts: BuildRedirectConfig): string {
  * @param entity `{ idp, sp }` handles
  * @param customTagReplacement optional custom template transformer
  * @param relayState per-request RelayState; falls back to `entitySetting.relayState`
+ * @param forceAuthn per-request `ForceAuthn` flag (saml-core §3.4.1)
  * @returns id + redirect URL wrapped in a {@link BindingContext}
  */
 function loginRequestRedirectURL(
   entity: { idp: Idp; sp: Sp },
   customTagReplacement?: (template: string) => BindingContext,
   relayState?: string,
+  forceAuthn?: boolean,
 ): BindingContext {
   const metadata = { idp: entity.idp.entityMeta, sp: entity.sp.entityMeta };
   const spSetting = entity.sp.entitySetting;
@@ -141,6 +143,9 @@ function loginRequestRedirectURL(
       AssertionConsumerServiceURL: metadata.sp.getAssertionConsumerService(binding.post) as string,
       EntityID: metadata.sp.getEntityID(),
       AllowCreate: spSetting.allowCreate,
+      // saml-core §3.4.1 — `replaceTagsByValue` drops the attribute when
+      // `forceAuthn` is undefined, matching `use="optional"`.
+      ForceAuthn: forceAuthn,
     };
     rawSamlRequest = libsaml.replaceTagsByValue(libsaml.defaultLoginRequestTemplate.context, tags);
   }

--- a/src/binding-simplesign.ts
+++ b/src/binding-simplesign.ts
@@ -94,11 +94,13 @@ function buildSimpleSignature(opts: BuildSimpleSignConfig): string {
  * @param entity `{ idp, sp }` handles
  * @param customTagReplacement optional custom template transformer
  * @param relayState per-request RelayState; falls back to `entitySetting.relayState`
+ * @param forceAuthn per-request `ForceAuthn` flag (saml-core §3.4.1)
  */
 function base64LoginRequest(
   entity: SimpleSignIdpSpPair,
   customTagReplacement?: (template: string) => BindingContext,
   relayState?: string,
+  forceAuthn?: boolean,
 ): SimpleSignComputedContext {
   const metadata = { idp: entity.idp.entityMeta, sp: entity.sp.entityMeta };
   const spSetting = entity.sp.entitySetting;
@@ -129,6 +131,9 @@ function base64LoginRequest(
       EntityID: metadata.sp.getEntityID(),
       AllowCreate: spSetting.allowCreate,
       NameIDFormat: selectedNameIDFormat,
+      // saml-core §3.4.1 — `replaceTagsByValue` drops the attribute when
+      // `forceAuthn` is undefined, matching `use="optional"`.
+      ForceAuthn: forceAuthn,
     };
     rawSamlRequest = libsaml.replaceTagsByValue(libsaml.defaultLoginRequestTemplate.context, tags);
   }

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -85,6 +85,10 @@ export class ServiceProvider extends Entity {
     const opts = normalizeCreateLoginRequestOptions(optionsOrCallback);
     const customTagReplacement = opts.customTagReplacement;
     const requestRelayState = opts.relayState ?? this.entitySetting.relayState;
+    // saml-core §3.4.1 — `ForceAuthn` is a per-request boolean flag; when
+    // true the IdP MUST re-authenticate the user instead of relying on a
+    // previous security context (saml-profiles §4.1.4.1).
+    const forceAuthn = opts.forceAuthn;
     const selectedBinding = binding ?? 'redirect';
 
     const nsBinding = namespace.binding;
@@ -109,6 +113,7 @@ export class ServiceProvider extends Entity {
           { idp, sp: this },
           customTagReplacement,
           requestRelayState,
+          forceAuthn,
         );
 
       case nsBinding.post:
@@ -116,6 +121,7 @@ export class ServiceProvider extends Entity {
           "/*[local-name(.)='AuthnRequest']",
           { idp, sp: this },
           customTagReplacement,
+          forceAuthn,
         );
         break;
 
@@ -124,6 +130,7 @@ export class ServiceProvider extends Entity {
           { idp, sp: this },
           customTagReplacement,
           requestRelayState,
+          forceAuthn,
         ) as SimpleSignBindingContext;
         break;
 

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -202,7 +202,7 @@ const libSaml = () => {
 
   /** Default AuthnRequest XML template. */
   const defaultLoginRequestTemplate: LoginRequestTemplate = {
-    context: '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" IssueInstant="{IssueInstant}" Destination="{Destination}" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="{AssertionConsumerServiceURL}"><saml:Issuer>{Issuer}</saml:Issuer><samlp:NameIDPolicy Format="{NameIDFormat}" AllowCreate="{AllowCreate}"/></samlp:AuthnRequest>',
+    context: '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" ForceAuthn="{ForceAuthn}" IssueInstant="{IssueInstant}" Destination="{Destination}" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="{AssertionConsumerServiceURL}"><saml:Issuer>{Issuer}</saml:Issuer><samlp:NameIDPolicy Format="{NameIDFormat}" AllowCreate="{AllowCreate}"/></samlp:AuthnRequest>',
   };
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,8 @@ export type CustomTagReplacement = (template: string) => BindingContext;
 export interface CreateLoginRequestOptions {
   relayState?: string;
   customTagReplacement?: CustomTagReplacement;
+  /** saml-core §3.4.1 — when true, the IdP MUST re-authenticate the user. */
+  forceAuthn?: boolean;
 }
 
 /** Per-request options accepted by `IdentityProvider#createLoginResponse`. */

--- a/test/units.ts
+++ b/test/units.ts
@@ -1401,3 +1401,102 @@ describe('Redirect binding endpoint discovery (closes #308 #405, saml-bindings �
       .toThrow('ERR_NO_REDIRECT_SLO_ENDPOINT');
   });
 });
+
+describe('ForceAuthn (#359, saml-core §3.4.1)', () => {
+  // saml-core §3.4.1 declares `ForceAuthn` as `xs:boolean` with
+  // `use="optional"` on `<samlp:AuthnRequest>`. saml-profiles §4.1.4.1
+  // pins the semantics: when "true", the IdP MUST authenticate the
+  // presenter directly rather than rely on a previous security context.
+
+  const idp = identityProvider({
+    privateKey: fs.readFileSync('./test/key/idp/privkey.pem'),
+    privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+    metadata: idpMetaXml,
+  });
+  const sp = serviceProvider({
+    privateKey: fs.readFileSync('./test/key/sp/privkey.pem'),
+    privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+    metadata: spMetaXml,
+  });
+
+  test('default AuthnRequest template renders ForceAuthn when set', () => {
+    const xml = libsaml.replaceTagsByValue(libsaml.defaultLoginRequestTemplate.context, {
+      ID: '_x',
+      Destination: 'https://idp/sso',
+      Issuer: 'https://sp/meta',
+      IssueInstant: '2026-05-01T00:00:00Z',
+      AssertionConsumerServiceURL: 'https://sp/acs',
+      NameIDFormat: 'fmt',
+      AllowCreate: true,
+      ForceAuthn: true,
+    });
+    expect(xml).toContain('ForceAuthn="true"');
+  });
+
+  test('default AuthnRequest template omits ForceAuthn when undefined', () => {
+    const xml = libsaml.replaceTagsByValue(libsaml.defaultLoginRequestTemplate.context, {
+      ID: '_x',
+      Destination: 'https://idp/sso',
+      Issuer: 'https://sp/meta',
+      IssueInstant: '2026-05-01T00:00:00Z',
+      AssertionConsumerServiceURL: 'https://sp/acs',
+      NameIDFormat: 'fmt',
+      AllowCreate: true,
+      ForceAuthn: undefined,
+    });
+    expect(xml).not.toContain('ForceAuthn=');
+  });
+
+  test('createLoginRequest (redirect): forceAuthn surfaces in the rendered XML', () => {
+    const result = sp.createLoginRequest(idp, 'redirect', { forceAuthn: true });
+    const url = new URL(result.context, 'http://example.test');
+    const inflated = require('zlib').inflateRawSync(
+      Buffer.from(decodeURIComponent(url.searchParams.get('SAMLRequest')!), 'base64'),
+    ).toString('utf8');
+    expect(inflated).toContain('ForceAuthn="true"');
+  });
+
+  test('createLoginRequest (post): forceAuthn surfaces in the rendered XML', () => {
+    const result = sp.createLoginRequest(idp, 'post', { forceAuthn: true });
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).toContain('ForceAuthn="true"');
+  });
+
+  test('createLoginRequest (simpleSign): forceAuthn surfaces in the rendered XML', () => {
+    const result = sp.createLoginRequest(idp, 'simpleSign', { forceAuthn: true });
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).toContain('ForceAuthn="true"');
+  });
+
+  test('backwards-compat: no options bag, no ForceAuthn attribute in the XML', () => {
+    const result = sp.createLoginRequest(idp, 'redirect');
+    const url = new URL(result.context, 'http://example.test');
+    const inflated = require('zlib').inflateRawSync(
+      Buffer.from(decodeURIComponent(url.searchParams.get('SAMLRequest')!), 'base64'),
+    ).toString('utf8');
+    expect(inflated).not.toContain('ForceAuthn=');
+  });
+
+  test('createLoginRequest (redirect): forceAuthn=false renders ForceAuthn="false"', () => {
+    // saml-core §3.4.1 — explicit `false` is still a valid xs:boolean and
+    // the IdP MAY rely on a previous security context. We render it verbatim.
+    const result = sp.createLoginRequest(idp, 'redirect', { forceAuthn: false });
+    const url = new URL(result.context, 'http://example.test');
+    const inflated = require('zlib').inflateRawSync(
+      Buffer.from(decodeURIComponent(url.searchParams.get('SAMLRequest')!), 'base64'),
+    ).toString('utf8');
+    expect(inflated).toContain('ForceAuthn="false"');
+  });
+
+  test('createLoginRequest (post): no options bag, no ForceAuthn attribute in the XML', () => {
+    const result = sp.createLoginRequest(idp, 'post');
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).not.toContain('ForceAuthn=');
+  });
+
+  test('createLoginRequest (simpleSign): no options bag, no ForceAuthn attribute in the XML', () => {
+    const result = sp.createLoginRequest(idp, 'simpleSign');
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).not.toContain('ForceAuthn=');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `forceAuthn?: boolean` to `CreateLoginRequestOptions` so callers can request that the IdP re-authenticate the presenter on a single login request, without mutating entity settings.
- Splice `ForceAuthn="{ForceAuthn}"` into the default `<samlp:AuthnRequest>` template; the `replaceTagsByValue` omission rule from #614 drops the attribute when the value is undefined, so existing callers see no behaviour change.
- Plumb `forceAuthn` from `ServiceProvider#createLoginRequest` through all three login bindings (redirect / post / simpleSign).

Closes #359.

## Spec reference

- `saml-core §3.4.1` — `ForceAuthn` attribute on `<samlp:AuthnRequest>` (`xs:boolean`, `use="optional"`).
- `saml-profiles §4.1.4.1` — Web Browser SSO Profile interpretation: "the identity provider MUST authenticate the presenter directly rather than rely on a previous security context".

## Test plan

- [x] `yarn test` — all existing + new tests pass (273 / 1 skipped).
- [x] `yarn coverage` — all four global thresholds (statements / branches / functions / lines) hold at >= 90%.
- [x] `npx tsc --noEmit` — clean.
- [x] Default AuthnRequest template renders `ForceAuthn="true"` when set.
- [x] Default AuthnRequest template omits the attribute when undefined.
- [x] Redirect binding emits `ForceAuthn="true"` after deflate + base64 round-trip.
- [x] Post binding emits `ForceAuthn="true"` after base64 decode.
- [x] SimpleSign binding emits `ForceAuthn="true"` after base64 decode.
- [x] Each binding omits `ForceAuthn=` entirely when no options bag is supplied (back-compat).
- [x] `forceAuthn: false` renders `ForceAuthn="false"` verbatim — still a valid `xs:boolean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)