### PR TITLE
feat: support tagPrefix.protocol and tagPrefix.assertion on IdP (closes #388)

### DIFF
--- a/src/binding-post.ts
+++ b/src/binding-post.ts
@@ -179,7 +179,11 @@ async function base64LoginResponse(
     if (requestInfo !== null && (requestInfo as RequestInfo).extract?.request) {
       tvalue.InResponseTo = (requestInfo as RequestInfo).extract.request!.id as string;
     }
-    rawSamlResponse = libsaml.replaceTagsByValue(libsaml.defaultLoginResponseTemplate.context, tvalue);
+    // saml-core §1.4: prefer the IdP-rewritten default when tagPrefix is
+    // overridden (closes #388); otherwise fall back to the library default.
+    const baseTemplate = idpSetting.tagPrefixedDefaults?.loginResponseTemplate?.context
+      ?? libsaml.defaultLoginResponseTemplate.context;
+    rawSamlResponse = libsaml.replaceTagsByValue(baseTemplate, tvalue);
   }
   const { privateKey, privateKeyPass, requestSignatureAlgorithm: signatureAlgorithm } = idpSetting;
   const config = {
@@ -290,7 +294,9 @@ function base64LogoutRequest(
       // drops the element when undefined (closes #470).
       SessionIndex: user.sessionIndex,
     };
-    rawSamlRequest = libsaml.replaceTagsByValue(libsaml.defaultLogoutRequestTemplate.context, tvalue);
+    const baseTemplate = initSetting.tagPrefixedDefaults?.logoutRequestTemplate?.context
+      ?? libsaml.defaultLogoutRequestTemplate.context;
+    rawSamlRequest = libsaml.replaceTagsByValue(baseTemplate, tvalue);
   }
   if (entity.target.entitySetting.wantLogoutRequestSigned) {
     const { privateKey, privateKeyPass, requestSignatureAlgorithm: signatureAlgorithm, transformationAlgorithms } = initSetting;
@@ -359,7 +365,9 @@ function base64LogoutResponse(
       StatusCode: StatusCode.Success,
       InResponseTo: get<string>(requestInfo as Record<string, unknown>, 'extract.request.id') as string,
     };
-    rawSamlResponse = libsaml.replaceTagsByValue(libsaml.defaultLogoutResponseTemplate.context, tvalue);
+    const baseTemplate = initSetting.tagPrefixedDefaults?.logoutResponseTemplate?.context
+      ?? libsaml.defaultLogoutResponseTemplate.context;
+    rawSamlResponse = libsaml.replaceTagsByValue(baseTemplate, tvalue);
   }
   if (entity.target.entitySetting.wantLogoutResponseSigned) {
     const { privateKey, privateKeyPass, requestSignatureAlgorithm: signatureAlgorithm, transformationAlgorithms } = initSetting;

--- a/src/binding-redirect.ts
+++ b/src/binding-redirect.ts
@@ -237,7 +237,11 @@ function loginResponseRedirectURL(
     if (requestInfo !== null && (requestInfo as RequestInfo).extract?.request) {
       tvalue.InResponseTo = (requestInfo as RequestInfo).extract.request!.id as string;
     }
-    rawSamlResponse = libsaml.replaceTagsByValue(libsaml.defaultLoginResponseTemplate.context, tvalue);
+    // saml-core §1.4: prefer the IdP-rewritten default when tagPrefix is
+    // overridden (closes #388); otherwise fall back to the library default.
+    const baseTemplate = idpSetting.tagPrefixedDefaults?.loginResponseTemplate?.context
+      ?? libsaml.defaultLoginResponseTemplate.context;
+    rawSamlResponse = libsaml.replaceTagsByValue(baseTemplate, tvalue);
   }
 
   const { privateKey, privateKeyPass, requestSignatureAlgorithm: signatureAlgorithm } = idpSetting;
@@ -325,7 +329,9 @@ function logoutRequestRedirectURL(
     id = get<string>(info as unknown as Record<string, unknown>, 'id') as string;
     rawSamlRequest = get<string>(info as unknown as Record<string, unknown>, 'context') as string;
   } else {
-    rawSamlRequest = libsaml.replaceTagsByValue(libsaml.defaultLogoutRequestTemplate.context, requiredTags as TagReplacementMap);
+    const baseTemplate = initSetting.tagPrefixedDefaults?.logoutRequestTemplate?.context
+      ?? libsaml.defaultLogoutRequestTemplate.context;
+    rawSamlRequest = libsaml.replaceTagsByValue(baseTemplate, requiredTags as TagReplacementMap);
   }
   return {
     id,
@@ -392,7 +398,9 @@ function logoutResponseRedirectURL(
     if (requestInfo && (requestInfo as RequestInfo).extract && (requestInfo as RequestInfo).extract.request) {
       tvalue.InResponseTo = (requestInfo as RequestInfo).extract.request!.id as string;
     }
-    rawSamlResponse = libsaml.replaceTagsByValue(libsaml.defaultLogoutResponseTemplate.context, tvalue);
+    const baseTemplate = initSetting.tagPrefixedDefaults?.logoutResponseTemplate?.context
+      ?? libsaml.defaultLogoutResponseTemplate.context;
+    rawSamlResponse = libsaml.replaceTagsByValue(baseTemplate, tvalue);
   }
   return {
     id,

--- a/src/binding-simplesign.ts
+++ b/src/binding-simplesign.ts
@@ -222,7 +222,11 @@ async function base64LoginResponse(
     if (requestInfo !== null && (requestInfo as RequestInfo).extract?.request) {
       tvalue.InResponseTo = (requestInfo as RequestInfo).extract.request!.id as string;
     }
-    rawSamlResponse = libsaml.replaceTagsByValue(libsaml.defaultLoginResponseTemplate.context, tvalue);
+    // saml-core §1.4: prefer the IdP-rewritten default when tagPrefix is
+    // overridden (closes #388); otherwise fall back to the library default.
+    const baseTemplate = idpSetting.tagPrefixedDefaults?.loginResponseTemplate?.context
+      ?? libsaml.defaultLoginResponseTemplate.context;
+    rawSamlResponse = libsaml.replaceTagsByValue(baseTemplate, tvalue);
   }
   const { privateKey, privateKeyPass, requestSignatureAlgorithm: signatureAlgorithm } = idpSetting;
   const config = {
@@ -307,7 +311,9 @@ function base64LogoutRequest(
       // drops the element when undefined (closes #470).
       SessionIndex: user.sessionIndex,
     };
-    rawSamlRequest = libsaml.replaceTagsByValue(libsaml.defaultLogoutRequestTemplate.context, tvalue);
+    const baseTemplate = initSetting.tagPrefixedDefaults?.logoutRequestTemplate?.context
+      ?? libsaml.defaultLogoutRequestTemplate.context;
+    rawSamlRequest = libsaml.replaceTagsByValue(baseTemplate, tvalue);
   }
 
   let simpleSignatureContext: { signature: string; sigAlg: string } | null = null;
@@ -371,7 +377,9 @@ function base64LogoutResponse(
       StatusCode: StatusCode.Success,
       InResponseTo: get<string>(requestInfo as Record<string, unknown>, 'extract.request.id') as string,
     };
-    rawSamlResponse = libsaml.replaceTagsByValue(libsaml.defaultLogoutResponseTemplate.context, tvalue);
+    const baseTemplate = initSetting.tagPrefixedDefaults?.logoutResponseTemplate?.context
+      ?? libsaml.defaultLogoutResponseTemplate.context;
+    rawSamlResponse = libsaml.replaceTagsByValue(baseTemplate, tvalue);
   }
 
   let simpleSignatureContext: { signature: string; sigAlg: string } | null = null;

--- a/src/entity-idp.ts
+++ b/src/entity-idp.ts
@@ -38,6 +38,35 @@ export default function (props: IdentityProviderSettings): IdentityProvider {
   return new IdentityProvider(props);
 }
 
+/**
+ * Swap the default `samlp:` / `saml:` prefixes inside an XML template
+ * with caller-supplied prefixes. Both the prefix occurrences and the
+ * `xmlns:` namespace bindings are rewritten so the resulting XML
+ * remains well-formed and namespace-correct (saml-core §1.4 — prefix
+ * choice is not normative).
+ */
+function applyTagPrefixes(
+  xml: string,
+  prefixes: { protocol?: string; assertion?: string },
+): string {
+  let out = xml;
+  if (prefixes.protocol && prefixes.protocol !== 'samlp') {
+    const p = prefixes.protocol;
+    out = out
+      .replace(/<samlp:/g, `<${p}:`)
+      .replace(/<\/samlp:/g, `</${p}:`)
+      .replace(/xmlns:samlp="/g, `xmlns:${p}="`);
+  }
+  if (prefixes.assertion && prefixes.assertion !== 'saml') {
+    const a = prefixes.assertion;
+    out = out
+      .replace(/<saml:/g, `<${a}:`)
+      .replace(/<\/saml:/g, `</${a}:`)
+      .replace(/xmlns:saml="/g, `xmlns:${a}="`);
+  }
+  return out;
+}
+
 /** Identity-provider entity. */
 export class IdentityProvider extends Entity {
 
@@ -55,6 +84,13 @@ export class IdentityProvider extends Entity {
       },
     };
     const entitySetting = Object.assign({}, defaultIdpEntitySetting, idpSetting) as IdentityProviderSettings;
+    // Deep-merge tagPrefix so callers can override `protocol` / `assertion`
+    // without dropping the `encryptedAssertion: 'saml'` default that
+    // libsaml.encryptAssertion depends on (#388, saml-core §1.4).
+    entitySetting.tagPrefix = {
+      ...defaultIdpEntitySetting.tagPrefix,
+      ...idpSetting.tagPrefix,
+    };
 
     if (idpSetting.loginResponseTemplate) {
       const template = idpSetting.loginResponseTemplate as typeof idpSetting.loginResponseTemplate & {
@@ -84,6 +120,60 @@ export class IdentityProvider extends Entity {
         console.warn('Invalid login response template');
       }
     }
+
+    // saml-core §1.4 — XML namespace prefixes are not normative; only the
+    // URI bindings are. When the caller overrides `tagPrefix.protocol` or
+    // `tagPrefix.assertion`, rewrite both the caller's templates and the
+    // built-in defaults so the bindings emit the rebound prefixes
+    // downstream (closes #388). The rewritten defaults land on a separate
+    // `tagPrefixedDefaults` slot so users that only set
+    // `loginResponseTemplate` (without `tagPrefix`) continue to follow the
+    // legacy binding fallback path.
+    const tp = entitySetting.tagPrefix;
+    const protocolPrefix = tp?.protocol;
+    const assertionPrefix = tp?.assertion;
+    const overridesProtocol = !!protocolPrefix && protocolPrefix !== 'samlp';
+    const overridesAssertion = !!assertionPrefix && assertionPrefix !== 'saml';
+    if (overridesProtocol || overridesAssertion) {
+      const prefixes = { protocol: protocolPrefix, assertion: assertionPrefix };
+      // Rewrite any caller-supplied templates in place so customTagReplacement
+      // consumers see the rebound prefixes too.
+      const callerLoginCtx = entitySetting.loginResponseTemplate?.context;
+      if (isString(callerLoginCtx)) {
+        entitySetting.loginResponseTemplate = {
+          ...entitySetting.loginResponseTemplate,
+          context: applyTagPrefixes(callerLoginCtx, prefixes),
+        };
+      }
+      const callerLogoutReqCtx = entitySetting.logoutRequestTemplate?.context;
+      if (isString(callerLogoutReqCtx)) {
+        entitySetting.logoutRequestTemplate = {
+          ...entitySetting.logoutRequestTemplate,
+          context: applyTagPrefixes(callerLogoutReqCtx, prefixes),
+        };
+      }
+      const callerLogoutRespCtx = entitySetting.logoutResponseTemplate?.context;
+      if (isString(callerLogoutRespCtx)) {
+        entitySetting.logoutResponseTemplate = {
+          ...entitySetting.logoutResponseTemplate,
+          context: applyTagPrefixes(callerLogoutRespCtx, prefixes),
+        };
+      }
+      // Pre-rewrite copies of the default templates so the bindings emit
+      // rebound prefixes when no caller template is supplied.
+      entitySetting.tagPrefixedDefaults = {
+        loginResponseTemplate: {
+          context: applyTagPrefixes(libsaml.defaultLoginResponseTemplate.context, prefixes),
+        },
+        logoutRequestTemplate: {
+          context: applyTagPrefixes(libsaml.defaultLogoutRequestTemplate.context, prefixes),
+        },
+        logoutResponseTemplate: {
+          context: applyTagPrefixes(libsaml.defaultLogoutResponseTemplate.context, prefixes),
+        },
+      };
+    }
+
     super(entitySetting, 'idp');
   }
 

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -117,7 +117,12 @@ export interface EntityLike {
     isAssertionEncrypted?: boolean;
     dataEncryptionAlgorithm?: string;
     keyEncryptionAlgorithm?: string;
-    tagPrefix?: Record<string, string>;
+    tagPrefix?: {
+      protocol?: string;
+      assertion?: string;
+      encryptedAssertion?: string;
+      [key: string]: string | undefined;
+    };
     encPrivateKey?: string | Buffer;
     encPrivateKeyPass?: string | Buffer;
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -322,5 +322,42 @@ export interface IdentityProviderSettings {
   wantLogoutResponseSigned?: boolean;
   wantAuthnRequestsSigned?: boolean;
   wantLogoutRequestSignedResponseSigned?: boolean;
-  tagPrefix?: Record<string, string>;
+  /**
+   * Override the XML namespace prefixes used when rendering the IdP's
+   * default request/response templates.
+   *
+   * - `protocol` rebinds the SAML protocol namespace
+   *   (`urn:oasis:names:tc:SAML:2.0:protocol`, default prefix `samlp`).
+   * - `assertion` rebinds the SAML assertion namespace
+   *   (`urn:oasis:names:tc:SAML:2.0:assertion`, default prefix `saml`).
+   * - `encryptedAssertion` is the prefix wrapped around
+   *   `<EncryptedAssertion>` inside `libsaml.encryptAssertion`.
+   *
+   * Per saml-core §1.4 the prefix choice is not normative — only the
+   * namespace URI bindings are. Some peers (legacy ADFS quirks, custom
+   * integrations) require non-standard prefixes; this lets callers swap
+   * `samlp:` ↔ `samlp2:` and `saml:` ↔ `saml2:` without supplying a fully
+   * custom template (closes #388).
+   */
+  tagPrefix?: {
+    /** Prefix bound to the SAML protocol namespace (default: 'samlp'). */
+    protocol?: string;
+    /** Prefix bound to the SAML assertion namespace (default: 'saml'). */
+    assertion?: string;
+    /** Prefix used when wrapping `<EncryptedAssertion>`. */
+    encryptedAssertion?: string;
+    [key: string]: string | undefined;
+  };
+  /**
+   * @internal Populated by the IdP constructor when `tagPrefix.protocol`
+   * or `tagPrefix.assertion` is overridden — pre-rewritten copies of the
+   * built-in default request/response templates that the bindings consume
+   * in place of the library-internal defaults. Not part of the public
+   * configuration surface.
+   */
+  tagPrefixedDefaults?: {
+    loginResponseTemplate?: SAMLDocumentTemplate;
+    logoutRequestTemplate?: SAMLDocumentTemplate;
+    logoutResponseTemplate?: SAMLDocumentTemplate;
+  };
 }

--- a/test/units.ts
+++ b/test/units.ts
@@ -1500,3 +1500,229 @@ describe('ForceAuthn (#359, saml-core §3.4.1)', () => {
     expect(decoded).not.toContain('ForceAuthn=');
   });
 });
+
+describe('IdP tagPrefix override (#388, saml-core §1.4)', () => {
+  // saml-core §1.4 — XML namespace prefixes are not normative; only the
+  // namespace URIs are. Callers can rebind them as long as the URI
+  // bindings remain correct. Some peers (legacy ADFS, custom integrations)
+  // require non-standard prefixes; this lets us swap `samlp:` ↔ `samlp2:`
+  // and `saml:` ↔ `saml2:` without supplying a fully custom template.
+
+  const idpKey = fs.readFileSync('./test/key/idp/privkey.pem');
+  const idpKeyPass = 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW';
+  const spKey = fs.readFileSync('./test/key/sp/privkey.pem');
+  const spKeyPass = 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px';
+
+  const sp = serviceProvider({ privateKey: spKey, privateKeyPass: spKeyPass, metadata: spMetaXml });
+  const requestInfo = { extract: { request: { id: '_req-id' } } } as any;
+
+  const decode = (b64: string) => Buffer.from(b64, 'base64').toString('utf8');
+
+  test('login response template uses overridden protocol prefix', async () => {
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+      tagPrefix: { protocol: 'samlp2' },
+    });
+    const result = await idp.createLoginResponse(sp, requestInfo, 'post', { email: 'u@x' });
+    const xml = decode((result as { context: string }).context);
+    expect(xml).toContain('<samlp2:Response');
+    expect(xml).toContain('xmlns:samlp2="urn:oasis:names:tc:SAML:2.0:protocol"');
+    expect(xml).not.toContain('<samlp:Response');
+  });
+
+  test('login response template uses overridden assertion prefix', async () => {
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+      tagPrefix: { assertion: 'saml2' },
+    });
+    const result = await idp.createLoginResponse(sp, requestInfo, 'post', { email: 'u@x' });
+    const xml = decode((result as { context: string }).context);
+    expect(xml).toContain('<saml2:Issuer');
+    expect(xml).toContain('<saml2:Assertion');
+    expect(xml).toContain('xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"');
+    expect(xml).not.toMatch(/<saml:Issuer/);
+  });
+
+  test('both prefixes overridden simultaneously land on the rendered XML', async () => {
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+      tagPrefix: { protocol: 'p2', assertion: 'a2' },
+    });
+    const result = await idp.createLoginResponse(sp, requestInfo, 'post', { email: 'u@x' });
+    const xml = decode((result as { context: string }).context);
+    expect(xml).toContain('<p2:Response');
+    expect(xml).toContain('<a2:Issuer');
+    expect(xml).toContain('<a2:Assertion');
+    expect(xml).toContain('xmlns:p2="urn:oasis:names:tc:SAML:2.0:protocol"');
+    expect(xml).toContain('xmlns:a2="urn:oasis:names:tc:SAML:2.0:assertion"');
+    expect(xml).not.toContain('<samlp:Response');
+    expect(xml).not.toMatch(/<saml:Issuer/);
+  });
+
+  test('default behaviour preserved when no tagPrefix overrides are supplied', async () => {
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+    });
+    const result = await idp.createLoginResponse(sp, requestInfo, 'post', { email: 'u@x' });
+    const xml = decode((result as { context: string }).context);
+    expect(xml).toContain('<samlp:Response');
+    expect(xml).toContain('<saml:Issuer');
+    expect(xml).toContain('xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"');
+    expect(xml).toContain('xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"');
+  });
+
+  test('caller-supplied loginResponseTemplate is rewritten too', () => {
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+      tagPrefix: { protocol: 'p2' },
+      // The IdP constructor rewrites the caller's template in place so
+      // customTagReplacement consumers see the rebound prefix too.
+      loginResponseTemplate: {
+        context: '<samlp:Response>{ID}</samlp:Response>',
+        attributes: [],
+      } as any,
+    });
+    const ctx = (idp.entitySetting.loginResponseTemplate as { context: string }).context;
+    expect(ctx).toContain('<p2:Response>');
+    expect(ctx).not.toContain('<samlp:Response>');
+  });
+
+  test('rewrite also applies to logoutRequest and logoutResponse default templates', () => {
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+      tagPrefix: { protocol: 'samlp2', assertion: 'saml2' },
+    });
+    const logoutReqResult = idp.createLogoutRequest(sp, 'post', { logoutNameID: 'u@x' }) as { context: string };
+    const reqXml = decode(logoutReqResult.context);
+    expect(reqXml).toContain('<samlp2:LogoutRequest');
+    expect(reqXml).toContain('<saml2:Issuer');
+    expect(reqXml).toContain('xmlns:samlp2="urn:oasis:names:tc:SAML:2.0:protocol"');
+
+    const logoutRespResult = idp.createLogoutResponse(
+      sp,
+      { extract: { request: { id: '_lr' } } } as any,
+      'post',
+      'state',
+    ) as { context: string };
+    const respXml = decode(logoutRespResult.context);
+    expect(respXml).toContain('<samlp2:LogoutResponse');
+    expect(respXml).toContain('<saml2:Issuer');
+  });
+
+  test('caller-supplied logoutRequestTemplate is rewritten too', () => {
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+      tagPrefix: { protocol: 'p2', assertion: 'a2' },
+      logoutRequestTemplate: {
+        context: '<samlp:LogoutRequest><saml:Issuer>{Issuer}</saml:Issuer></samlp:LogoutRequest>',
+      },
+    });
+    const ctx = (idp.entitySetting.logoutRequestTemplate as { context: string }).context;
+    expect(ctx).toContain('<p2:LogoutRequest>');
+    expect(ctx).toContain('<a2:Issuer>');
+    expect(ctx).not.toContain('<samlp:');
+    expect(ctx).not.toContain('<saml:');
+  });
+
+  test('caller-supplied logoutResponseTemplate is rewritten too', () => {
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+      tagPrefix: { protocol: 'p2', assertion: 'a2' },
+      logoutResponseTemplate: {
+        context: '<samlp:LogoutResponse><saml:Issuer>{Issuer}</saml:Issuer></samlp:LogoutResponse>',
+      },
+    });
+    const ctx = (idp.entitySetting.logoutResponseTemplate as { context: string }).context;
+    expect(ctx).toContain('<p2:LogoutResponse>');
+    expect(ctx).toContain('<a2:Issuer>');
+    expect(ctx).not.toContain('<samlp:');
+    expect(ctx).not.toContain('<saml:');
+  });
+
+  test('redirect binding picks up the rewritten default templates', async () => {
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+      tagPrefix: { protocol: 'p2', assertion: 'a2' },
+    });
+    // login response over redirect
+    const loginResp = await idp.createLoginResponse(sp, requestInfo, 'redirect', { email: 'u@x' });
+    const loginResponseQuery = (loginResp.context as string).split('SAMLResponse=')[1].split('&')[0];
+    const loginXml = require('zlib')
+      .inflateRawSync(Buffer.from(decodeURIComponent(loginResponseQuery), 'base64'))
+      .toString('utf8');
+    expect(loginXml).toContain('<p2:Response');
+    expect(loginXml).toContain('<a2:Assertion');
+
+    // logout request over redirect
+    const logoutReq = idp.createLogoutRequest(sp, 'redirect', { logoutNameID: 'u@x' });
+    const reqQuery = (logoutReq.context as string).split('SAMLRequest=')[1].split('&')[0];
+    const reqXml = require('zlib')
+      .inflateRawSync(Buffer.from(decodeURIComponent(reqQuery), 'base64'))
+      .toString('utf8');
+    expect(reqXml).toContain('<p2:LogoutRequest');
+    expect(reqXml).toContain('<a2:Issuer');
+
+    // logout response over redirect
+    const logoutResp = idp.createLogoutResponse(sp, { extract: { request: { id: '_lr' } } } as any, 'redirect', '');
+    const respQuery = (logoutResp.context as string).split('SAMLResponse=')[1].split('&')[0];
+    const respXml = require('zlib')
+      .inflateRawSync(Buffer.from(decodeURIComponent(respQuery), 'base64'))
+      .toString('utf8');
+    expect(respXml).toContain('<p2:LogoutResponse');
+    expect(respXml).toContain('<a2:Issuer');
+  });
+
+  test('simpleSign binding picks up the rewritten default templates', async () => {
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+      tagPrefix: { protocol: 'p2', assertion: 'a2' },
+    });
+    const loginResp = await idp.createLoginResponse(sp, requestInfo, 'simpleSign', { email: 'u@x' });
+    const loginXml = decode((loginResp as { context: string }).context);
+    expect(loginXml).toContain('<p2:Response');
+    expect(loginXml).toContain('<a2:Assertion');
+
+    const logoutReq = idp.createLogoutRequest(sp, 'simpleSign', { logoutNameID: 'u@x' });
+    const reqXml = decode((logoutReq as { context: string }).context);
+    expect(reqXml).toContain('<p2:LogoutRequest');
+    expect(reqXml).toContain('<a2:Issuer');
+
+    const logoutResp = idp.createLogoutResponse(sp, { extract: { request: { id: '_lr' } } } as any, 'simpleSign', '');
+    const respXml = decode((logoutResp as { context: string }).context);
+    expect(respXml).toContain('<p2:LogoutResponse');
+    expect(respXml).toContain('<a2:Issuer');
+  });
+
+  test('encryptedAssertion prefix continues to be honoured independently', () => {
+    // Defaults to 'saml' on every IdP — preserved when the new
+    // protocol/assertion overrides are introduced.
+    const idp = identityProvider({
+      privateKey: idpKey,
+      privateKeyPass: idpKeyPass,
+      metadata: idpMetaXml,
+      tagPrefix: { protocol: 'samlp2', encryptedAssertion: 'saml' },
+    });
+    expect(idp.entitySetting.tagPrefix?.encryptedAssertion).toBe('saml');
+    expect(idp.entitySetting.tagPrefix?.protocol).toBe('samlp2');
+  });
+});


### PR DESCRIPTION
## Summary

- Lets IdP callers override the default `samlp:` / `saml:` namespace prefixes used in the built-in loginResponse, logoutRequest, and logoutResponse templates without supplying a fully custom template.
- Extends `IdentityProviderSettings.tagPrefix` from a flat `Record<string, string>` to a structured `{ protocol?, assertion?, encryptedAssertion? }` shape; the existing `tagPrefix.encryptedAssertion` semantics on `libsaml.encryptAssertion` are unchanged.
- Closes #388.

## Spec reference

- `saml-core §1.4` — XML namespace prefixes are not normative; only the namespace URI bindings are. Callers can rebind `samlp:` / `saml:` to alternative prefixes (e.g. `samlp2:` / `saml2:`) as long as the URI bindings remain correct, which some peers (legacy ADFS quirks, custom integrations) require.

## Test plan

- [x] Login response template uses the overridden protocol prefix (`<samlp2:Response`, `xmlns:samlp2="…protocol"`).
- [x] Login response template uses the overridden assertion prefix (`<saml2:Issuer`, `<saml2:Assertion`, `xmlns:saml2="…assertion"`).
- [x] Both prefixes overridden simultaneously land on the rendered XML.
- [x] Default behaviour preserved when no `tagPrefix` overrides are supplied (byte-identical to current master).
- [x] Caller-supplied `loginResponseTemplate` is rewritten in place so customTagReplacement consumers see the rebound prefix.
- [x] Caller-supplied `logoutRequestTemplate` and `logoutResponseTemplate` are rewritten in place.
- [x] Redirect binding picks up the rewritten defaults (login response, logout request, logout response).
- [x] SimpleSign binding picks up the rewritten defaults (login response, logout request, logout response).
- [x] `tagPrefix.encryptedAssertion` continues to be honoured independently of the new `protocol` / `assertion` overrides.
- [x] `yarn test` — 275 tests pass, 1 skipped.
- [x] `yarn coverage` — branch coverage 90.51% (≥ 90% threshold).
- [x] `npx tsc` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)