### PR TITLE
feat: per-request AssertionConsumerServiceIndex for createLoginRequest (closes #437)

### DIFF
--- a/src/binding-post.ts
+++ b/src/binding-post.ts
@@ -40,6 +40,9 @@ interface PostInitTargetPair {
  * @param entity `{ idp, sp }` handles
  * @param customTagReplacement optional custom template transformer
  * @param forceAuthn per-request `ForceAuthn` flag (saml-core §3.4.1)
+ * @param assertionConsumerServiceIndex per-request ACS index (saml-core §3.4.1).
+ *   Mutually exclusive with `AssertionConsumerServiceURL` / `ProtocolBinding`;
+ *   when supplied, both of those attributes are dropped from the rendered XML.
  * @returns id / base64-XML pair
  */
 function base64LoginRequest(
@@ -47,6 +50,7 @@ function base64LoginRequest(
   entity: PostIdpSpPair,
   customTagReplacement?: (template: string) => BindingContext,
   forceAuthn?: boolean,
+  assertionConsumerServiceIndex?: number,
 ): BindingContext {
   const metadata = { idp: entity.idp.entityMeta, sp: entity.sp.entityMeta };
   const spSetting = entity.sp.entitySetting;
@@ -74,12 +78,24 @@ function base64LoginRequest(
     const nameIDFormat = spSetting.nameIDFormat;
     const selectedNameIDFormat = Array.isArray(nameIDFormat) ? nameIDFormat[0] : nameIDFormat;
     id = spSetting.generateID!();
+    // saml-core §3.4.1 — `AssertionConsumerServiceIndex` is mutually
+    // exclusive with `AssertionConsumerServiceURL` / `ProtocolBinding`.
+    // When the caller supplies the index we set the URL+ProtocolBinding
+    // tags to undefined so `replaceTagsByValue` drops both attributes
+    // from the rendered XML (closes #437).
+    const useAcsIndex = assertionConsumerServiceIndex !== undefined;
     const tags: TagReplacementMap = {
       ID: id,
       Destination: base as string,
       Issuer: metadata.sp.getEntityID(),
       IssueInstant: new Date().toISOString(),
-      AssertionConsumerServiceURL: metadata.sp.getAssertionConsumerService(binding.post) as string,
+      ProtocolBinding: useAcsIndex
+        ? undefined
+        : 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+      AssertionConsumerServiceURL: useAcsIndex
+        ? undefined
+        : metadata.sp.getAssertionConsumerService(binding.post) as string,
+      AssertionConsumerServiceIndex: assertionConsumerServiceIndex,
       EntityID: metadata.sp.getEntityID(),
       AllowCreate: spSetting.allowCreate,
       NameIDFormat: selectedNameIDFormat,

--- a/src/binding-redirect.ts
+++ b/src/binding-redirect.ts
@@ -94,6 +94,9 @@ function buildRedirectURL(opts: BuildRedirectConfig): string {
  * @param customTagReplacement optional custom template transformer
  * @param relayState per-request RelayState; falls back to `entitySetting.relayState`
  * @param forceAuthn per-request `ForceAuthn` flag (saml-core §3.4.1)
+ * @param assertionConsumerServiceIndex per-request ACS index (saml-core §3.4.1).
+ *   Mutually exclusive with `AssertionConsumerServiceURL` / `ProtocolBinding`;
+ *   when supplied, both of those attributes are dropped from the rendered XML.
  * @returns id + redirect URL wrapped in a {@link BindingContext}
  */
 function loginRequestRedirectURL(
@@ -101,6 +104,7 @@ function loginRequestRedirectURL(
   customTagReplacement?: (template: string) => BindingContext,
   relayState?: string,
   forceAuthn?: boolean,
+  assertionConsumerServiceIndex?: number,
 ): BindingContext {
   const metadata = { idp: entity.idp.entityMeta, sp: entity.sp.entityMeta };
   const spSetting = entity.sp.entitySetting;
@@ -140,13 +144,25 @@ function loginRequestRedirectURL(
     const nameIDFormat = spSetting.nameIDFormat;
     const selectedNameIDFormat = Array.isArray(nameIDFormat) ? nameIDFormat[0] : nameIDFormat;
     id = spSetting.generateID!();
+    // saml-core §3.4.1 — `AssertionConsumerServiceIndex` is mutually
+    // exclusive with `AssertionConsumerServiceURL` / `ProtocolBinding`.
+    // When the caller supplies the index we set the URL+ProtocolBinding
+    // tags to undefined so `replaceTagsByValue` drops both attributes
+    // from the rendered XML (closes #437).
+    const useAcsIndex = assertionConsumerServiceIndex !== undefined;
     const tags: TagReplacementMap = {
       ID: id,
       Destination: base as string,
       Issuer: metadata.sp.getEntityID(),
       IssueInstant: new Date().toISOString(),
       NameIDFormat: selectedNameIDFormat,
-      AssertionConsumerServiceURL: metadata.sp.getAssertionConsumerService(binding.post) as string,
+      ProtocolBinding: useAcsIndex
+        ? undefined
+        : 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+      AssertionConsumerServiceURL: useAcsIndex
+        ? undefined
+        : metadata.sp.getAssertionConsumerService(binding.post) as string,
+      AssertionConsumerServiceIndex: assertionConsumerServiceIndex,
       EntityID: metadata.sp.getEntityID(),
       AllowCreate: spSetting.allowCreate,
       // saml-core §3.4.1 — `replaceTagsByValue` drops the attribute when

--- a/src/binding-simplesign.ts
+++ b/src/binding-simplesign.ts
@@ -95,12 +95,16 @@ function buildSimpleSignature(opts: BuildSimpleSignConfig): string {
  * @param customTagReplacement optional custom template transformer
  * @param relayState per-request RelayState; falls back to `entitySetting.relayState`
  * @param forceAuthn per-request `ForceAuthn` flag (saml-core §3.4.1)
+ * @param assertionConsumerServiceIndex per-request ACS index (saml-core §3.4.1).
+ *   Mutually exclusive with `AssertionConsumerServiceURL` / `ProtocolBinding`;
+ *   when supplied, both of those attributes are dropped from the rendered XML.
  */
 function base64LoginRequest(
   entity: SimpleSignIdpSpPair,
   customTagReplacement?: (template: string) => BindingContext,
   relayState?: string,
   forceAuthn?: boolean,
+  assertionConsumerServiceIndex?: number,
 ): SimpleSignComputedContext {
   const metadata = { idp: entity.idp.entityMeta, sp: entity.sp.entityMeta };
   const spSetting = entity.sp.entitySetting;
@@ -127,12 +131,24 @@ function base64LoginRequest(
     const nameIDFormat = spSetting.nameIDFormat;
     const selectedNameIDFormat = Array.isArray(nameIDFormat) ? nameIDFormat[0] : nameIDFormat;
     id = spSetting.generateID!();
+    // saml-core §3.4.1 — `AssertionConsumerServiceIndex` is mutually
+    // exclusive with `AssertionConsumerServiceURL` / `ProtocolBinding`.
+    // When the caller supplies the index we set the URL+ProtocolBinding
+    // tags to undefined so `replaceTagsByValue` drops both attributes
+    // from the rendered XML (closes #437).
+    const useAcsIndex = assertionConsumerServiceIndex !== undefined;
     const tags: TagReplacementMap = {
       ID: id,
       Destination: base as string,
       Issuer: metadata.sp.getEntityID(),
       IssueInstant: new Date().toISOString(),
-      AssertionConsumerServiceURL: metadata.sp.getAssertionConsumerService(binding.simpleSign) as string,
+      ProtocolBinding: useAcsIndex
+        ? undefined
+        : 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+      AssertionConsumerServiceURL: useAcsIndex
+        ? undefined
+        : metadata.sp.getAssertionConsumerService(binding.simpleSign) as string,
+      AssertionConsumerServiceIndex: assertionConsumerServiceIndex,
       EntityID: metadata.sp.getEntityID(),
       AllowCreate: spSetting.allowCreate,
       NameIDFormat: selectedNameIDFormat,

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -89,6 +89,12 @@ export class ServiceProvider extends Entity {
     // true the IdP MUST re-authenticate the user instead of relying on a
     // previous security context (saml-profiles §4.1.4.1).
     const forceAuthn = opts.forceAuthn;
+    // saml-core §3.4.1 — `AssertionConsumerServiceIndex` is mutually
+    // exclusive with `AssertionConsumerServiceURL` / `ProtocolBinding`.
+    // When set, the binding builders omit both of those attributes so the
+    // request only references the metadata-declared endpoint by index
+    // (saml-profiles §4.1.4.1).
+    const assertionConsumerServiceIndex = opts.assertionConsumerServiceIndex;
     const selectedBinding = binding ?? 'redirect';
 
     const nsBinding = namespace.binding;
@@ -114,6 +120,7 @@ export class ServiceProvider extends Entity {
           customTagReplacement,
           requestRelayState,
           forceAuthn,
+          assertionConsumerServiceIndex,
         );
 
       case nsBinding.post:
@@ -122,6 +129,7 @@ export class ServiceProvider extends Entity {
           { idp, sp: this },
           customTagReplacement,
           forceAuthn,
+          assertionConsumerServiceIndex,
         );
         break;
 
@@ -131,6 +139,7 @@ export class ServiceProvider extends Entity {
           customTagReplacement,
           requestRelayState,
           forceAuthn,
+          assertionConsumerServiceIndex,
         ) as SimpleSignBindingContext;
         break;
 

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -269,9 +269,18 @@ const libSaml = () => {
     };
   }
 
-  /** Default AuthnRequest XML template. */
+  /**
+   * Default AuthnRequest XML template.
+   *
+   * Per saml-core §3.4.1, `ProtocolBinding`, `AssertionConsumerServiceURL`,
+   * and `AssertionConsumerServiceIndex` are all `use="optional"` and
+   * mutually exclusive — when the index is set, neither URL nor
+   * ProtocolBinding may be present. All three are placeholders here so
+   * that `replaceTagsByValue` drops whichever the caller leaves
+   * undefined (closes #437).
+   */
   const defaultLoginRequestTemplate: LoginRequestTemplate = {
-    context: '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" ForceAuthn="{ForceAuthn}" IssueInstant="{IssueInstant}" Destination="{Destination}" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="{AssertionConsumerServiceURL}"><saml:Issuer>{Issuer}</saml:Issuer><samlp:NameIDPolicy Format="{NameIDFormat}" AllowCreate="{AllowCreate}"/></samlp:AuthnRequest>',
+    context: '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{ID}" Version="2.0" ForceAuthn="{ForceAuthn}" IssueInstant="{IssueInstant}" Destination="{Destination}" ProtocolBinding="{ProtocolBinding}" AssertionConsumerServiceURL="{AssertionConsumerServiceURL}" AssertionConsumerServiceIndex="{AssertionConsumerServiceIndex}"><saml:Issuer>{Issuer}</saml:Issuer><samlp:NameIDPolicy Format="{NameIDFormat}" AllowCreate="{AllowCreate}"/></samlp:AuthnRequest>',
   };
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,23 @@ export interface CreateLoginRequestOptions {
   customTagReplacement?: CustomTagReplacement;
   /** saml-core §3.4.1 — when true, the IdP MUST re-authenticate the user. */
   forceAuthn?: boolean;
+  /**
+   * saml-core §3.4.1 — `<samlp:AuthnRequest>` may identify the desired ACS
+   * endpoint either by URL+ProtocolBinding *or* by an index into the SP's
+   * metadata. The three attributes are mutually exclusive: "If the
+   * `<AssertionConsumerServiceIndex>` attribute is present, neither
+   * `<AssertionConsumerServiceURL>` nor `<ProtocolBinding>` may be set."
+   *
+   * When this option is set, samlify omits both `AssertionConsumerServiceURL`
+   * and `ProtocolBinding` from the rendered request — including any
+   * metadata-derived ACS URL the SP would otherwise inject. In other words,
+   * if the caller sets `assertionConsumerServiceIndex`, the index wins;
+   * mutual exclusion enforcement is the caller's responsibility.
+   *
+   * Useful for IdPs (legacy Shibboleth, certain ADFS configurations) that
+   * prefer the metadata-indexed form per saml-profiles §4.1.4.1.
+   */
+  assertionConsumerServiceIndex?: number;
 }
 
 /** Per-request options accepted by `IdentityProvider#createLoginResponse`. */

--- a/test/units.ts
+++ b/test/units.ts
@@ -2301,3 +2301,150 @@ describe('customTagReplacement without explicit template (#549)', () => {
     });
   });
 });
+
+describe('AssertionConsumerServiceIndex (#437, saml-core §3.4.1)', () => {
+  // saml-core §3.4.1 declares `AssertionConsumerServiceIndex`,
+  // `AssertionConsumerServiceURL`, and `ProtocolBinding` as `use="optional"`
+  // and mutually exclusive: "If the `<AssertionConsumerServiceIndex>`
+  // attribute is present, neither `<AssertionConsumerServiceURL>` nor
+  // `<ProtocolBinding>` may be set." saml-profiles §4.1.4.1 permits the
+  // index form so the IdP can resolve the ACS endpoint from SP metadata.
+
+  const idp = identityProvider({
+    privateKey: fs.readFileSync('./test/key/idp/privkey.pem'),
+    privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+    metadata: idpMetaXml,
+  });
+  const sp = serviceProvider({
+    privateKey: fs.readFileSync('./test/key/sp/privkey.pem'),
+    privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+    metadata: spMetaXml,
+  });
+
+  const inflateRedirect = (urlString: string): string => {
+    const u = new URL(urlString, 'http://example.test');
+    const samlRequest = decodeURIComponent(u.searchParams.get('SAMLRequest')!);
+    return require('zlib')
+      .inflateRawSync(Buffer.from(samlRequest, 'base64'))
+      .toString('utf8');
+  };
+
+  test('default template renders AssertionConsumerServiceIndex and drops URL+ProtocolBinding when index is set', () => {
+    const xml = libsaml.replaceTagsByValue(libsaml.defaultLoginRequestTemplate.context, {
+      ID: '_x',
+      Destination: 'https://idp/sso',
+      Issuer: 'https://sp/meta',
+      IssueInstant: '2026-05-01T00:00:00Z',
+      NameIDFormat: 'fmt',
+      AllowCreate: true,
+      ProtocolBinding: undefined,
+      AssertionConsumerServiceURL: undefined,
+      AssertionConsumerServiceIndex: 0,
+    });
+    expect(xml).toContain('AssertionConsumerServiceIndex="0"');
+    expect(xml).not.toContain('ProtocolBinding=');
+    expect(xml).not.toContain('AssertionConsumerServiceURL=');
+  });
+
+  test('default template renders URL+ProtocolBinding when index is undefined (legacy behaviour)', () => {
+    const xml = libsaml.replaceTagsByValue(libsaml.defaultLoginRequestTemplate.context, {
+      ID: '_x',
+      Destination: 'https://idp/sso',
+      Issuer: 'https://sp/meta',
+      IssueInstant: '2026-05-01T00:00:00Z',
+      NameIDFormat: 'fmt',
+      AllowCreate: true,
+      ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+      AssertionConsumerServiceURL: 'https://sp/acs',
+      AssertionConsumerServiceIndex: undefined,
+    });
+    expect(xml).toContain('ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"');
+    expect(xml).toContain('AssertionConsumerServiceURL="https://sp/acs"');
+    expect(xml).not.toContain('AssertionConsumerServiceIndex=');
+  });
+
+  test('default template legacy snapshot is byte-identical to master (modulo ID/IssueInstant)', () => {
+    // Pin the default-rendered XML so backwards-compatible callers
+    // produce exactly the same bytes they did before #437.
+    const xml = libsaml.replaceTagsByValue(libsaml.defaultLoginRequestTemplate.context, {
+      ID: '_pinned',
+      Destination: 'https://idp/sso',
+      Issuer: 'https://sp/meta',
+      IssueInstant: '2026-05-01T00:00:00Z',
+      NameIDFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+      AllowCreate: true,
+      ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+      AssertionConsumerServiceURL: 'https://sp/acs',
+      AssertionConsumerServiceIndex: undefined,
+      ForceAuthn: undefined,
+    });
+    expect(xml).toBe(
+      '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"' +
+        ' xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_pinned"' +
+        ' Version="2.0" IssueInstant="2026-05-01T00:00:00Z"' +
+        ' Destination="https://idp/sso"' +
+        ' ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"' +
+        ' AssertionConsumerServiceURL="https://sp/acs">' +
+        '<saml:Issuer>https://sp/meta</saml:Issuer>' +
+        '<samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"' +
+        ' AllowCreate="true"/>' +
+        '</samlp:AuthnRequest>',
+    );
+  });
+
+  test('createLoginRequest (redirect): index renders, URL and ProtocolBinding omitted', () => {
+    const result = sp.createLoginRequest(idp, 'redirect', { assertionConsumerServiceIndex: 1 });
+    const inflated = inflateRedirect(result.context);
+    expect(inflated).toContain('AssertionConsumerServiceIndex="1"');
+    expect(inflated).not.toContain('AssertionConsumerServiceURL=');
+    expect(inflated).not.toContain('ProtocolBinding=');
+  });
+
+  test('createLoginRequest (post): index renders, URL and ProtocolBinding omitted', () => {
+    const result = sp.createLoginRequest(idp, 'post', { assertionConsumerServiceIndex: 2 });
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).toContain('AssertionConsumerServiceIndex="2"');
+    expect(decoded).not.toContain('AssertionConsumerServiceURL=');
+    expect(decoded).not.toContain('ProtocolBinding=');
+  });
+
+  test('createLoginRequest (simpleSign): index renders, URL and ProtocolBinding omitted', () => {
+    const result = sp.createLoginRequest(idp, 'simpleSign', { assertionConsumerServiceIndex: 3 });
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).toContain('AssertionConsumerServiceIndex="3"');
+    expect(decoded).not.toContain('AssertionConsumerServiceURL=');
+    expect(decoded).not.toContain('ProtocolBinding=');
+  });
+
+  test('createLoginRequest (redirect): index=0 still renders the attribute (truthy/falsy edge)', () => {
+    const result = sp.createLoginRequest(idp, 'redirect', { assertionConsumerServiceIndex: 0 });
+    const inflated = inflateRedirect(result.context);
+    expect(inflated).toContain('AssertionConsumerServiceIndex="0"');
+    expect(inflated).not.toContain('AssertionConsumerServiceURL=');
+    expect(inflated).not.toContain('ProtocolBinding=');
+  });
+
+  test('backwards-compat: redirect with no options keeps URL and ProtocolBinding', () => {
+    const result = sp.createLoginRequest(idp, 'redirect');
+    const inflated = inflateRedirect(result.context);
+    expect(inflated).toContain('ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"');
+    expect(inflated).toContain('AssertionConsumerServiceURL=');
+    expect(inflated).not.toContain('AssertionConsumerServiceIndex=');
+  });
+
+  test('backwards-compat: post with no options keeps URL and ProtocolBinding', () => {
+    const result = sp.createLoginRequest(idp, 'post');
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).toContain('ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"');
+    expect(decoded).toContain('AssertionConsumerServiceURL=');
+    expect(decoded).not.toContain('AssertionConsumerServiceIndex=');
+  });
+
+  test('backwards-compat: simpleSign with no options keeps URL and ProtocolBinding', () => {
+    const result = sp.createLoginRequest(idp, 'simpleSign');
+    const decoded = Buffer.from(result.context, 'base64').toString('utf8');
+    expect(decoded).toContain('ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"');
+    expect(decoded).toContain('AssertionConsumerServiceURL=');
+    expect(decoded).not.toContain('AssertionConsumerServiceIndex=');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `assertionConsumerServiceIndex?: number` to `CreateLoginRequestOptions` so SP callers can issue `<samlp:AuthnRequest AssertionConsumerServiceIndex="N" ...>` instead of the URL + ProtocolBinding pair, closing #437.
- When the option is set, `AssertionConsumerServiceURL` and `ProtocolBinding` are both omitted from the rendered request (mutual exclusion per saml-core §3.4.1). The metadata-derived ACS URL the SP would otherwise inject is also suppressed; the index wins.
- Backwards-compat is preserved byte-for-byte: callers that don't pass the new option produce the same XML as before #437 (pinned with a literal-string compare in tests, modulo `ID=` and `IssueInstant=`).

## Spec reference

- `saml-core §3.4.1` — `<samlp:AuthnRequest>` schema: `AssertionConsumerServiceIndex`, `AssertionConsumerServiceURL`, and `ProtocolBinding` are all `use="optional"` and mutually exclusive ("If the `<AssertionConsumerServiceIndex>` attribute is present, neither `<AssertionConsumerServiceURL>` nor `<ProtocolBinding>` may be set").
- `saml-profiles §4.1.4.1` — Web Browser SSO Profile permits the index form; the IdP resolves the endpoint from the SP's metadata.

## Implementation notes

- `defaultLoginRequestTemplate` now uses placeholders for all three attributes. The omission rule shipped in #614 (attribute is dropped when its value is `null`/`undefined`) handles the swap, so no new omission logic was introduced.
- `entity-sp.ts:createLoginRequest` extracts the new option (mirroring the `forceAuthn` shape from #618) and forwards it to `binding-redirect.ts`, `binding-post.ts`, and `binding-simplesign.ts`, each of which sets `ProtocolBinding` / `AssertionConsumerServiceURL` to `undefined` when the index is supplied.

## Test plan

- [x] Default template renders `AssertionConsumerServiceIndex` and drops `AssertionConsumerServiceURL` + `ProtocolBinding` when the index is set.
- [x] Default template renders `AssertionConsumerServiceURL` + `ProtocolBinding` and drops the index when `AssertionConsumerServiceIndex` is undefined (regression for legacy default behaviour).
- [x] Byte-identical legacy snapshot pinned via literal-string compare on the rendered AuthnRequest (modulo `ID=` / `IssueInstant=`).
- [x] `sp.createLoginRequest(idp, 'redirect', { assertionConsumerServiceIndex: 1 })` — inflated SAMLRequest contains `AssertionConsumerServiceIndex="1"`, no URL, no ProtocolBinding.
- [x] Same shape verified for `'post'` and `'simpleSign'` bindings.
- [x] `index=0` edge case — falsy but defined; the attribute still renders.
- [x] Backwards-compat: each binding without the options bag continues to emit `ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"` and `AssertionConsumerServiceURL=`.
- [x] `yarn test` — 302 passing / 1 skipped.
- [x] `yarn coverage` — ≥90 % on every metric (statements 97.33, branches 90.87, functions 99.15, lines 97.33).
- [x] `npx tsc` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)