### PR TITLE
fix: restore Express request type compatibility in ESamlHttpRequest (closes #626)

### DIFF
--- a/.pre-commit.sh
+++ b/.pre-commit.sh
@@ -6,7 +6,11 @@ echo "Compiling"
 $(npm bin)/tsc
 BUILDRESULT=$?
 
-if [[ $LINTRESULT -ne 0 || $BUILDRESULT -ne 0 ]]; then
+echo "Type guards"
+$(npm bin)/tsc -p tsconfig.typecheck.json
+TYPEGUARDRESULT=$?
+
+if [[ $LINTRESULT -ne 0 || $BUILDRESULT -ne 0 || $TYPEGUARDRESULT -ne 0 ]]; then
   echo "Fix errors before commit"
   exit 1
 else

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint": "tslint -p .",
     "lint:fix": "tslint -p . --fix",
     "pretest": "mkdir -p build/test && cp -a test/key test/misc build/test",
-    "test": "NODE_ENV=test vitest run",
+    "test:types": "tsc -p tsconfig.typecheck.json",
+    "test": "NODE_ENV=test vitest run && yarn test:types",
     "test:watch": "NODE_ENV=test vitest",
     "coverage": "vitest run --coverage",
     "hooks:postinstall": "ln -sf $PWD/.pre-commit.sh $PWD/.git/hooks/pre-commit"

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,10 +90,20 @@ export type ExtractorFields = ExtractorField[];
 /**
  * Minimal HTTP request shape the library consumes from the caller's web
  * framework. Only the fields SAML needs are typed.
+ *
+ * `query` / `body` are intentionally typed as `Record<string, unknown>`
+ * rather than `Record<string, string | undefined>`. The latter is *not*
+ * structurally assignable from Express's `Request` (`req.query` is
+ * `qs.ParsedQs`, whose values may be `string[]` or nested objects), which
+ * would force every Express/Koa/Fastify caller to cast — a breaking change
+ * for TypeScript consumers relative to the pre-2.13 `any` typing. `unknown`
+ * keeps the surface stricter than `any` while remaining backward compatible
+ * with every web framework's request object. The binding/flow code narrows
+ * these values at the point of use.
  */
 export interface ESamlHttpRequest {
-  query?: Record<string, string | undefined>;
-  body?: Record<string, string | undefined>;
+  query?: Record<string, unknown>;
+  body?: Record<string, unknown>;
   octetString?: string;
 }
 

--- a/test/typecheck/express-request-compat.ts
+++ b/test/typecheck/express-request-compat.ts
@@ -1,0 +1,76 @@
+/**
+ * Compile-time regression guard for issue #626.
+ *
+ * 2.13.0 (commit 3d5788a) tightened `ESamlHttpRequest.query` / `.body`
+ * from `any` to `Record<string, string | undefined>`. That type is NOT
+ * structurally assignable from an Express `Request` — `req.query` is
+ * `qs.ParsedQs`, whose values may be `string[]` or nested objects — so
+ * every Express/Koa/Fastify caller passing `req` (or `req.query`) into
+ * `parseLoginRequest` / `parseLoginResponse` / `parseLogoutRequest` /
+ * `parseLogoutResponse` started failing to compile (TS2345 / TS2322).
+ *
+ * This file is type-checked (not run) via `tsconfig.typecheck.json`,
+ * wired into `yarn test`. It has no runtime assertions on purpose: the
+ * regression is purely at the type level, so a vitest runtime test
+ * (types erased) cannot catch it.
+ *
+ * If `ESamlHttpRequest` ever regresses to a value type that rejects
+ * `ParsedQs`, the positive assignments below stop compiling and this
+ * guard fails. The `@ts-expect-error` block pins the exact #626 failure
+ * mode and proves the Express mock genuinely reproduces it (if the mock
+ * is weakened so it no longer reproduces, that line errors instead).
+ */
+import type { ESamlHttpRequest } from '../../src/types';
+
+/**
+ * Exact shape of Express's `req.query` (`qs.ParsedQs` from @types/qs,
+ * as re-exported by @types/express-serve-static-core). Hand-rolled so
+ * this guard needs no `@types/express` devDependency.
+ */
+interface ParsedQs {
+  [key: string]: undefined | string | ParsedQs | (string | ParsedQs)[];
+}
+
+/** Minimal structural stand-in for an Express `Request`. */
+interface ExpressLikeRequest {
+  query: ParsedQs;
+  // Express types `req.body` as `any` by default; model it faithfully.
+  body: any;
+}
+
+declare const req: ExpressLikeRequest;
+
+// --- positive: the supported caller patterns must all type-check ---
+
+// raw Express request passed straight through (the common case)
+const _whole: ESamlHttpRequest = req;
+
+// destructured into the documented `{ query, body }` shape
+const _split: ESamlHttpRequest = { query: req.query, body: req.body };
+
+// redirect binding: query only
+const _queryOnly: ESamlHttpRequest = { query: req.query };
+
+// post / simpleSign binding: body only
+const _bodyOnly: ESamlHttpRequest = { body: req.body };
+
+// --- self-test: pin the exact pre-fix failure mode of #626 ---
+// The 2.13.0 type genuinely rejected the Express query shape. If this
+// stops erroring, the Express mock above no longer reproduces #626 and
+// the positive assertions are no longer meaningful.
+interface PreFixESamlHttpRequest {
+  query?: Record<string, string | undefined>;
+  body?: Record<string, string | undefined>;
+  octetString?: string;
+}
+// @ts-expect-error -- ParsedQs is not assignable to Record<string, string | undefined>
+const _regressed: PreFixESamlHttpRequest = { query: req.query };
+
+// reference the bindings so unused-locals settings can't strip the file
+export const __issue626Guard = [
+  _whole,
+  _split,
+  _queryOnly,
+  _bodyOnly,
+  _regressed,
+] as const;

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "test/typecheck/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,10 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['test/**/*.ts'],
-    exclude: ['node_modules', 'build'],
+    // test/typecheck/** is compile-time-only (tsconfig.typecheck.json /
+    // `yarn test:types`); it has no runtime assertions, so keep vitest
+    // from collecting it as an empty/failing suite.
+    exclude: ['node_modules', 'build', 'test/typecheck/**'],
     globals: true,
     environment: 'node',
     coverage: {


### PR DESCRIPTION
## Problem (#626)

2.13.0 (commit 3d5788a) tightened `ESamlHttpRequest.query` / `.body` from `any` to `Record<string, string | undefined>`. That type is **not** structurally assignable from an Express `Request` — `req.query` is `qs.ParsedQs`, whose values may be `string[]` or nested objects. So every Express/Koa/Fastify caller passing `req` (or `req.query`) into `parseLoginRequest` / `parseLoginResponse` / `parseLogoutRequest` / `parseLogoutResponse` started failing to compile (`TS2345` / `TS2322`) — a breaking change shipped in a **minor** version.

Runtime was never affected (TS interfaces are erased); this is purely a compile-time regression for TypeScript consumers.

## Fix

Loosen `query` / `body` to `Record<string, unknown>`:

- Backward compatible with the pre-2.13 `any` typing and every web framework's request object (Express `ParsedQs`, Koa, Fastify, raw Node).
- Still stricter than `any`, preserving the intent of the 3d5788a refactor.
- The binding/flow code already narrows these values at the point of use (`flow.ts:89/209/309`), so nothing internal relies on the field type.

## Regression guard

A runtime vitest test can't catch this (types erased; `test/**` excluded from base `tsc`), so the guard is a type-checked test:

- `test/typecheck/express-request-compat.ts` — asserts an Express-shaped request (hand-rolled `qs.ParsedQs`, **no `@types/express` devDep**) is assignable to `ESamlHttpRequest`, with a `@ts-expect-error` self-test pinning the exact pre-fix failure mode.
- `tsconfig.typecheck.json` — type-checks it under the base strictness.
- Wired into `yarn test` (`test:types`) and `.pre-commit.sh` so a future regression fails the build.
- `vitest.config.ts` excludes `test/typecheck/**` (compile-time only).

## Verification

- **Differential proof:** guard **fails** with the exact #626 `TS2322` when `ESamlHttpRequest` is reverted to the 2.13.0 shape, and **passes** on the fix — so it's a real guard, not trivially green.
- Express `Request` from real `@types/express` (`--strict`) is assignable four ways: raw `req`, destructured `{ query, body }`, query-only, body-only.
- Full vitest suite: 337 passed / 1 skipped. Base `tsc` and lint clean.

## Out of scope (separate follow-up)

The reporter also flagged commit `fee4ff1` as an undocumented breaking change. That is a **separate, deliberate** security fix — `constructMessageSignature` no longer defaults to RSA-SHA1 (now RSA-SHA256), and unknown algorithm URIs throw instead of silently downgrading. It is unrelated to Express request consumption and is correctly documented in the commit message; it should be surfaced in the v2.13.0 release notes, but that's a docs/release task outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)